### PR TITLE
Fixed path returned by temp_filename not writeable

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -443,7 +443,7 @@ end
 
 function core.temp_filename(ext)
   temp_file_counter = temp_file_counter + 1
-  return EXEDIR .. PATHSEP .. temp_file_prefix
+  return USERDIR .. PATHSEP .. temp_file_prefix
       .. string.format("%06x", temp_file_counter) .. (ext or "")
 end
 


### PR DESCRIPTION
The path returned by temp_filename was not writeable on UNIX (and possibly other OS). This lead to the gitstatus plugin not working.
The proposed change fixes this by using the USERDIR variable instead of EXEDIR