### PR TITLE
Full path in window title option

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -18,6 +18,5 @@ config.tab_type = "soft"
 config.line_limit = 80
 config.max_symbols = 4000
 config.max_project_files = 2000
-config.full_path_in_window_title = false
 
 return config

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -18,5 +18,6 @@ config.tab_type = "soft"
 config.line_limit = 80
 config.max_symbols = 4000
 config.max_project_files = 2000
+config.full_path_in_window_title = false
 
 return config

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -7,6 +7,7 @@ local keymap
 local RootView
 local StatusView
 local CommandView
+local DocView
 local Doc
 
 local core = {}
@@ -688,6 +689,7 @@ function core.step()
   local did_keymap = false
   local mouse_moved = false
   local mouse = { x = 0, y = 0, dx = 0, dy = 0 }
+  DocView = require "core.docview"
 
   for type, a,b,c,d in system.poll_event do
     if type == "mousemoved" then
@@ -725,7 +727,7 @@ function core.step()
 
   -- update window title
   local name = core.active_view:get_name()
-  local title = (name ~= "---") and ( (config.full_path_in_window_title and core.active_view.doc.filename or name) .. " - lite") or  "lite"
+  local title = (name ~= "---") and ( (config.full_path_in_window_title and core.active_view:is(DocView) and core.active_view.doc.filename or name) .. " - lite") or  "lite"
   if title ~= core.window_title then
     system.set_window_title(title)
     core.window_title = title

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -330,6 +330,7 @@ function core.init()
   RootView = require "core.rootview"
   StatusView = require "core.statusview"
   CommandView = require "core.commandview"
+  DocView = require "core.docview"
   Doc = require "core.doc"
 
   do
@@ -689,7 +690,7 @@ function core.step()
   local did_keymap = false
   local mouse_moved = false
   local mouse = { x = 0, y = 0, dx = 0, dy = 0 }
-  DocView = require "core.docview"
+  
 
   for type, a,b,c,d in system.poll_event do
     if type == "mousemoved" then
@@ -727,7 +728,7 @@ function core.step()
 
   -- update window title
   local name = core.active_view:get_name()
-  local title = (name ~= "---") and ( (config.full_path_in_window_title and core.active_view:is(DocView) and core.active_view.doc.filename or name) .. " - lite") or  "lite"
+  local title = (name ~= "---") and ( (core.active_view:is(DocView) and core.active_view.doc.filename or name) .. " - lite") or  "lite"
   if title ~= core.window_title then
     system.set_window_title(title)
     core.window_title = title

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -725,7 +725,7 @@ function core.step()
 
   -- update window title
   local name = core.active_view:get_name()
-  local title = (name ~= "---") and (name .. " - lite") or  "lite"
+  local title = (name ~= "---") and ( (config.full_path_in_window_title and core.active_view.doc.filename or name) .. " - lite") or  "lite"
   if title ~= core.window_title then
     system.set_window_title(title)
     core.window_title = title


### PR DESCRIPTION
I realized it would be really handy if the full path to the currently open file would be visible in the window title.
I couldn't figure out how to achieve this without modifying core.step(), hence this patch. 

If it is possible to achieve this with a plugin instead, it would be interesting to see how, I am new to Lua and couldn't figure it out.

Also I didn't know how to format the code, i don't think the long line my hack did looks good, but wasn't sure what the best way to do it is.

I also tried formatting the path with, `common.home_encode()`, but figured I actually prefer it being expanded for my usecase, but maybe most people rather have it encoded. Perhaps, making the option a 3 state thing?  
`config.full_path_in_window_title = expanded | yes | no`  

