### PR TITLE
User module auto reload

### DIFF
--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -107,12 +107,6 @@ command.add(nil, {
   ["core:open-user-module"] = function()
     local user_module_doc = core.open_doc(USERDIR .. "/init.lua")
     if not user_module_doc then return end
-    local doc_save = user_module_doc.save
-    user_module_doc.save = function(self)
-      doc_save(self)
-      core.reload_module("core.style")
-      core.load_user_directory()
-    end
     core.root_view:open_doc(user_module_doc)
   end,
 

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -67,6 +67,10 @@ end
 
 local function save(filename)
   doc():save(filename)
+  if doc().filename == (USERDIR .. "/init.lua") then
+    core.reload_module("core.style")
+    core.load_user_directory()
+  end
   core.log("Saved \"%s\"", doc().filename)
 end
 

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -67,7 +67,7 @@ end
 
 local function save(filename)
   doc():save(filename)
-  if doc().filename == (USERDIR .. "/init.lua") then
+  if doc().filename == (USERDIR .. PATHSEP .. "init.lua") then
     core.reload_module("core.style")
     core.load_user_directory()
   end


### PR DESCRIPTION
I found it a bit annoying that if the user module (USERDIR .. "/init.lua") was open in the editor, but without being opened with the command `Core: Open User Module`, the config didn't autoreload.

With this patch, configuration will always auto reload when the user module is saved, no matter how it was opened.