### PR TITLE
FIX: only encode if title has changed. Keep title in CommandView

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -93,7 +93,7 @@ end
 function DocView:get_fullname()
   local post = self.doc:is_dirty() and "*" or ""
   local filename = self.doc.filename
-  return not filename and "---" or filename .. post
+  return not filename and "unsaved" or filename .. post
 end
 
 

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -93,7 +93,7 @@ end
 function DocView:get_fullname()
   local post = self.doc:is_dirty() and "*" or ""
   local filename = self.doc.filename
-  return filename and common.home_encode(system.absolute_path(filename)) .. post or "unsaved"
+  return not filename and "---" or filename .. post
 end
 
 

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -686,8 +686,12 @@ end
 
 
 local function window_title_for_view(view)
-  local doc_filename = view:is(DocView) and view:get_fullname() or view:get_name()
-  return (doc_filename ~= "---") and doc_filename .. " - lite" or "lite"
+  if core.active_view:is(CommandView) then
+    return core.window_title
+  else
+    local doc_filename = view:is(DocView) and view:get_fullname() or view:get_name()
+    return (doc_filename ~= "---") and doc_filename .. " - lite" or "lite"
+  end
 end
 
 
@@ -735,8 +739,9 @@ function core.step()
   -- update window title
   local title = window_title_for_view(core.active_view)
   if title ~= core.window_title then
-    system.set_window_title(title)
     core.window_title = title
+    title = common.home_encode(title)
+    system.set_window_title(title)
   end
 
   -- draw


### PR DESCRIPTION
I was worried about adding `common.home_encode(title)` in my initial PR #32 , thinking it would put weight on step(). With this test it will only encode if the title is changed (should be called way less), but this means that it will try to encode any title, i don't think that should cause any issues (since strings not starting with HOME dir will be returned untounched). But it is not super clean. I also removed the getfullpath function, because of this. Not sure if the full path thing is needed, isn't `doc.filename` always absolute?

I also found it a bit annoying that everytime i brought up the command palette (CommandView), the title changed to "unchanged", so I made it so that if the current view is CommandView it will return the last title, which in turn means no change of the title.