### PR TITLE
Clamp the size of the TreeView to a minimum of 0

### DIFF
--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -194,6 +194,7 @@ function TreeView:update()
       self.goto_size = nil
     end
   end
+  self.size.x = math.max(0, self.size.x)
 
   TreeView.super.update(self)
 end


### PR DESCRIPTION
Fixes #44. I'm not sure if there's a more clean way of doing this, I scoured the RootView's code but couldn't find how the sizes of DocViews are exactly clamped, so I did this. Hopefully it's not too horrible!