### PR TITLE
Fix #30 – user plugins take priority over built-in plugins

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -535,16 +535,18 @@ end
 
 function core.load_plugins()
   local no_errors = true
-  for _, root_dir in ipairs {DATADIR, USERDIR} do
+  local loaded = {}
+  for _, root_dir in ipairs {USERDIR, DATADIR} do
     local files = system.list_dir(root_dir .. "/plugins")
     for _, filename in ipairs(files or {}) do
       local basename = filename:gsub(".lua$", "")
-      if config[basename] ~= false then
+      if config[basename] ~= false and not loaded[basename] then
         local modname = "plugins." .. basename
         local ok = core.try(require, modname)
+        loaded[basename] = ok
         -- Normally a log line is added for each loaded plugin which is a
         -- good thing. Unfortunately we load the user module before the plugins
-        -- so all the messages here can fill the log screen and hide an evential
+        -- so all the messages here can fill the log screen and hide an eventual
         -- user module's error.
         -- if ok then core.log_quiet("Loaded plugin %q", modname) end
         if not ok then
@@ -760,7 +762,7 @@ function core.step()
   local did_keymap = false
   local mouse_moved = false
   local mouse = { x = 0, y = 0, dx = 0, dy = 0 }
-  
+
 
   for type, a,b,c,d in system.poll_event do
     if type == "mousemoved" then

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -542,7 +542,7 @@ function core.load_plugins()
       if system.get_file_info(plugin_path).type == "file" then
         basename = basename:match("(.-)%.lua$")
       end
-      if config[basename] ~= false then
+      if basename ~= nil and config[basename] ~= false then
         local modname = "plugins." .. basename
         local ok = core.try(require, modname)
         -- Normally a log line is added for each loaded plugin which is a

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -535,15 +535,13 @@ end
 
 function core.load_plugins()
   local no_errors = true
-  local loaded = {}
   for _, root_dir in ipairs {USERDIR, DATADIR} do
     local files = system.list_dir(root_dir .. "/plugins")
     for _, filename in ipairs(files or {}) do
       local basename = filename:gsub(".lua$", "")
-      if config[basename] ~= false and not loaded[basename] then
+      if config[basename] ~= false then
         local modname = "plugins." .. basename
         local ok = core.try(require, modname)
-        loaded[basename] = ok
         -- Normally a log line is added for each loaded plugin which is a
         -- good thing. Unfortunately we load the user module before the plugins
         -- so all the messages here can fill the log screen and hide an eventual

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -537,8 +537,11 @@ function core.load_plugins()
   local no_errors = true
   for _, root_dir in ipairs {USERDIR, DATADIR} do
     local files = system.list_dir(root_dir .. "/plugins")
-    for _, filename in ipairs(files or {}) do
-      local basename = filename:gsub(".lua$", "")
+    for _, plugin_path in ipairs(files or {}) do
+      local basename = common.basename(plugin_path)
+      if system.get_file_info(plugin_path).type == "file" then
+        basename = basename:match("(.-)%.lua$")
+      end
       if config[basename] ~= false then
         local modname = "plugins." .. basename
         local ok = core.try(require, modname)

--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -10,8 +10,8 @@ local prefix = EXEDIR:match("^(.+)[/\\]bin$")
 DATADIR = prefix and (prefix .. '/share/lite-xl') or (EXEDIR .. '/data')
 USERDIR = HOME and (HOME .. '/.config/lite-xl') or (EXEDIR .. '/user')
 
-package.path = package.path .. ';' .. USERDIR .. '/?.lua'
-package.path = package.path .. ';' .. USERDIR .. '/?/init.lua'
 package.path = DATADIR .. '/?.lua;' .. package.path
 package.path = DATADIR .. '/?/init.lua;' .. package.path
+package.path = USERDIR .. '/?.lua;' .. package.path
+package.path = USERDIR .. '/?/init.lua;' .. package.path
 


### PR DESCRIPTION
I don't know how ugly this solution is, considering that it messes with the package search path. In my opinion the plugin system should be changed not to use `require` though, and use `dofile()` together with setting keys in `package.loaded` or `package.preload`, so that it's not prone to cases like this. On the other hand, some plugins like my own lint+ are composed of multiple modules, so having the package search path contain the user configuration directory is quite useful. I'm just not sure about this change, which involves changing the order of package search paths in `package.path`.

Closes #30 