### PR TITLE
Make animation speed independent of config.fps, add config.animation_rate to fine-tune animation speed

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -19,6 +19,7 @@ config.line_limit = 80
 config.max_symbols = 4000
 config.max_project_files = 2000
 config.transitions = true
+config.animation_rate = 1.0
 config.blink_period = 0.8
 
 -- Disable plugin loading setting to false the config entry

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -20,13 +20,14 @@ function View:move_towards(t, k, dest, rate)
   if type(t) ~= "table" then
     return self:move_towards(self, t, k, dest, rate)
   end
-  rate = rate or 0.5
-  rate = common.clamp(rate * (60/config.fps) * config.animation_rate, 0.0, 1.0)
   local val = t[k]
   if not config.transitions or math.abs(val - dest) < 0.5 then
     t[k] = dest
   else
-    t[k] = common.lerp(val, dest, rate)
+    rate = common.clamp(rate or 0.5, 1e-8, 1 - 1e-8)
+    local alpha = math.log(1 - rate) * config.animation_rate
+    local dt = 60 / config.fps
+    t[k] = common.lerp(val, dest, 1 - math.exp(alpha * dt))
   end
   if val ~= dest then
     core.redraw = true

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -17,15 +17,16 @@ function View:new()
 end
 
 function View:move_towards(t, k, dest, rate)
-  rate = rate * config.animation_rate
   if type(t) ~= "table" then
     return self:move_towards(self, t, k, dest, rate)
   end
+  rate = rate or 0.5
+  rate = common.clamp(rate * (60/config.fps) * config.animation_rate, 0.0, 1.0)
   local val = t[k]
   if not config.transitions or math.abs(val - dest) < 0.5 then
     t[k] = dest
   else
-    t[k] = common.lerp(val, dest, rate or 0.5)
+    t[k] = common.lerp(val, dest, rate)
   end
   if val ~= dest then
     core.redraw = true

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -17,6 +17,7 @@ function View:new()
 end
 
 function View:move_towards(t, k, dest, rate)
+  rate = rate * config.animation_rate
   if type(t) ~= "table" then
     return self:move_towards(self, t, k, dest, rate)
   end


### PR DESCRIPTION
Despite my research of this topic mentioned in #91, I still feel like the animation speed is off by *just* a tiny bit, but then that's what `config.animation_rate` is for—if you dislike the stock animation rate, then you're free to change it to whatever you want.

Note that `config.animation_rate` *does not* replace `config.transitions`: setting `config.animation_rate` to a very high value will make animations fast, ugly, and jittery instead of disabling them. That's simply not what the setting was designed for, so `config.transitions` still has its place.

Closes #91.