### PR TITLE
Replicate Vim backspace and CTRL-C behaviour

### DIFF
--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -84,7 +84,6 @@ function keymap.vim_execute(verb, mult, object)
 end
 
 keymap.reset_vim_command()
-
 local modkeys = { "ctrl", "alt", "altgr", "shift" }
 
 local function key_to_stroke(k)
@@ -154,9 +153,12 @@ function keymap.on_key_pressed(k)
         return true
       end
     elseif mode == 'insert' then
-      if stroke == 'escape' then
+      if stroke == 'escape' or stroke == 'ctrl+c' then
         core.set_editing_mode(core.active_view, 'command')
         return true
+      end
+      if stroke == 'backspace' then
+        command.perform('doc:backspace')
       end
       return false
     end

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -84,6 +84,7 @@ function keymap.vim_execute(verb, mult, object)
 end
 
 keymap.reset_vim_command()
+
 local modkeys = { "ctrl", "alt", "altgr", "shift" }
 
 local function key_to_stroke(k)


### PR DESCRIPTION
Currently backspace does not function in insert mode and CTRL-C should exit insert mode as described in the official [documentation](https://vimhelp.org/insert.txt.html).

I would also like to propose a [roadmap](https://github.com/VSCodeVim/Vim/blob/master/ROADMAP.md).