### PR TITLE
Added in a routine to pull out the directory of the file being opened…

### DIFF
--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -88,7 +88,7 @@ command.add(nil, {
   ["core:open-file"] = function()
     local view = core.active_view
     if view and view.doc and view.doc.filename then
-      core.command_view:set_text(view.doc.filename:match("(.*[/\\])(.+)$"))
+      core.command_view:set_text((view.doc.filename:find("..") and view.doc.abs_filename or view.doc.filename):match("(.*[/\\])(.+)$"))
     end
     core.command_view:enter("Open File", function(text)
       core.root_view:open_doc(core.open_doc(common.home_expand(text)))

--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -88,7 +88,7 @@ command.add(nil, {
   ["core:open-file"] = function()
     local view = core.active_view
     if view and view.doc and view.doc.filename then
-      core.command_view:set_text((view.doc.filename:find("..") and view.doc.abs_filename or view.doc.filename):match("(.*[/\\])(.+)$"))
+      core.command_view:set_text((view.doc.filename:find("%.%.") and view.doc.abs_filename or view.doc.filename):match("(.*[/\\])(.+)$"))
     end
     core.command_view:enter("Open File", function(text)
       core.root_view:open_doc(core.open_doc(common.home_expand(text)))

--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -86,18 +86,13 @@ command.add(nil, {
   end,
 
   ["core:open-file"] = function()
-    local suggestion = nil
     if core.active_view ~= nil and core.active_view.doc ~= nil and core.active_view.doc.filename ~= nil then
-      suggestion = core.active_view.doc.filename:match("(.*[/\\])(.+)$")
+      core.command_view:set_text(core.active_view.doc.filename:match("(.*[/\\])(.+)$"))
     end
     core.command_view:enter("Open File", function(text)
       core.root_view:open_doc(core.open_doc(common.home_expand(text)))
     end, function (text)
-      local list = common.home_encode_list(common.path_suggest(common.home_expand(text)))
-      if suggestion and text:match("^%s*$") then
-        table.insert(list, 1, suggestion)
-      end
-      return list
+      return common.home_encode_list(common.path_suggest(common.home_expand(text)))
     end)
   end,
 

--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -86,8 +86,9 @@ command.add(nil, {
   end,
 
   ["core:open-file"] = function()
-    if core.active_view ~= nil and core.active_view.doc ~= nil and core.active_view.doc.filename ~= nil then
-      core.command_view:set_text(core.active_view.doc.filename:match("(.*[/\\])(.+)$"))
+    local view = core.active_view
+    if view and view.doc and view.doc.filename then
+      core.command_view:set_text(view.doc.filename:match("(.*[/\\])(.+)$"))
     end
     core.command_view:enter("Open File", function(text)
       core.root_view:open_doc(core.open_doc(common.home_expand(text)))

--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -90,7 +90,7 @@ command.add(nil, {
     local view_idx = node:get_view_idx(core.active_view)
     if view_idx ~= nil then
       local view = node.views[view_idx]
-      if view.doc ~= nil and view.doc.filename then
+      if view.doc ~= nil and view.doc.filename ~= nil then
         local directory, filename = view.doc.filename:match("(.*)[/\\](.+)$")
         core.command_view:set_text(directory .. PATHSEP)
       end

--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -86,19 +86,18 @@ command.add(nil, {
   end,
 
   ["core:open-file"] = function()
-    local node = core.root_view:get_active_node_default()
-    local view_idx = node:get_view_idx(core.active_view)
-    if view_idx ~= nil then
-      local view = node.views[view_idx]
-      if view.doc ~= nil and view.doc.filename ~= nil then
-        local directory, filename = view.doc.filename:match("(.*)[/\\](.+)$")
-        core.command_view:set_text(directory .. PATHSEP)
-      end
+    local suggestion = nil
+    if core.active_view ~= nil and core.active_view.doc ~= nil and core.active_view.doc.filename ~= nil then
+      suggestion = core.active_view.doc.filename:match("(.*[/\\])(.+)$")
     end
     core.command_view:enter("Open File", function(text)
       core.root_view:open_doc(core.open_doc(common.home_expand(text)))
     end, function (text)
-      return common.home_encode_list(common.path_suggest(common.home_expand(text)))
+      local list = common.home_encode_list(common.path_suggest(common.home_expand(text)))
+      if suggestion and text:match("^%s*$") then
+        table.insert(list, 1, suggestion)
+      end
+      return list
     end)
   end,
 

--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -86,6 +86,15 @@ command.add(nil, {
   end,
 
   ["core:open-file"] = function()
+    local node = core.root_view:get_active_node_default()
+    local view_idx = node:get_view_idx(core.active_view)
+    if view_idx ~= nil then
+      local view = node.views[view_idx]
+      if view.doc ~= nil then
+        local directory, filename = view.doc.filename:match("(.*)[/\\](.+)$")
+        core.command_view:set_text(directory .. PATHSEP)
+      end
+    end
     core.command_view:enter("Open File", function(text)
       core.root_view:open_doc(core.open_doc(common.home_expand(text)))
     end, function (text)

--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -90,7 +90,7 @@ command.add(nil, {
     local view_idx = node:get_view_idx(core.active_view)
     if view_idx ~= nil then
       local view = node.views[view_idx]
-      if view.doc ~= nil then
+      if view.doc ~= nil and view.doc.filename then
         local directory, filename = view.doc.filename:match("(.*)[/\\](.+)$")
         core.command_view:set_text(directory .. PATHSEP)
       end


### PR DESCRIPTION
… based on the currently selected view. This is more in line with other editors (kate, gedit, etc..); saves you time from having to type for related files.

Please reject the request if these kind of default behavioural changes aren't desired; I can probably write this in as a plugin if it shouldn't be part of the core.