### PR TITLE
Nested Syntax Highlighting

### DIFF
--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -50,7 +50,7 @@ local function retrieve_syntax_state(incoming_syntax, state)
       if target ~= 0 then
         if current_syntax.patterns[target].syntax then
           subsyntax_info = current_syntax.patterns[target]
-          current_syntax = syntax.get(current_syntax.patterns[target].syntax)
+          current_syntax = type(current_syntax.patterns[target].syntax) == "table" and current_syntax.patterns[target].syntax or syntax.get(current_syntax.patterns[target].syntax)
           current_state = 0
           current_level = i+1
         else
@@ -134,7 +134,7 @@ function tokenizer.tokenize(incoming_syntax, text, state)
           if p.syntax then
             current_level = current_level + 1
             subsyntax_info = p
-            current_syntax = syntax.get(p.syntax)
+            current_syntax = type(p.syntax) == "table" and p.syntax or syntax.get(p.syntax)
             current_state = 0
           else        
             current_state = n

--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -38,22 +38,24 @@ local function find_non_escaped(text, pattern, offset, esc)
   end
 end
 
--- State is a 32-bit number that is four separate bytes, illustrating how many differnet delimiters 
--- we have open, and which subsyntaxes we have active. At most, there are 3 subsyntaxes active at the 
--- same time. Beyond that, does not support further highlighting.
+-- State is a 32-bit number that is four separate bytes, illustrating how many 
+-- differnet delimiters we have open, and which subsyntaxes we have active. 
+-- At most, there are 3 subsyntaxes active at the same time. Beyond that, 
+-- does not support further highlighting.
 local function retrieve_syntax_state(incoming_syntax, state)
-  local current_syntax, subsyntax_info, current_state, current_level = incoming_syntax, nil, state, 0
+  local current_syntax, subsyntax_info, current_state, current_level = 
+    incoming_syntax, nil, state, 0
   if state > 0 and (state > 255 or current_syntax.patterns[state].syntax) then
-    -- If we have higher bits, then decode them one at a time, and find which syntax we're using.
-    -- TODO: Rather than walking the bytes, and calling into `syntax` each time, we could probably cache
-    -- this in a single table.
+    -- If we have higher bits, then decode them one at a time, and find which 
+    -- syntax we're using. Rather than walking the bytes, and calling into 
+    -- `syntax` each time, we could probably cache this in a single table.
     for i=0,2 do
       local target = bit32.extract(state, i*8, 8)
       if target ~= 0 then
         if current_syntax.patterns[target].syntax then
           subsyntax_info = current_syntax.patterns[target]
-          current_syntax = type(subsyntax_info.syntax) == "table" and subsyntax_info.syntax 
-            or syntax.get(subsyntax_info.syntax)
+          current_syntax = type(subsyntax_info.syntax) == "table" and 
+            subsyntax_info.syntax or syntax.get(subsyntax_info.syntax)
           current_state = 0
           current_level = i+1
         else
@@ -86,9 +88,15 @@ function tokenizer.tokenize(incoming_syntax, text, state)
       local s, e = find_non_escaped(text, p.pattern[2], i, p.pattern[3])
       
       local cont = true
-      -- If we're in subsyntax mode, always check to see if we end our syntax first.
+      -- If we're in subsyntax mode, always check to see if we end our syntax
+      -- first.
       if subsyntax_info then
-        local ss, se = find_non_escaped(text, subsyntax_info.pattern[2], i, subsyntax_info.pattern[3])
+        local ss, se = find_non_escaped(
+	  text, 
+	  subsyntax_info.pattern[2], 
+	  i, 
+	  subsyntax_info.pattern[3]
+	)
         if ss and (s == nil or ss < s) then
           push_token(res, p.type, text:sub(i, ss - 1))          
           i = ss
@@ -109,7 +117,12 @@ function tokenizer.tokenize(incoming_syntax, text, state)
     end
     -- Check for end of syntax.
     if subsyntax_info then
-      local s, e = find_non_escaped(text, "^" .. subsyntax_info.pattern[2], i, nil)
+      local s, e = find_non_escaped(
+        text, 
+	"^" .. subsyntax_info.pattern[2], 
+	i, 
+	nil
+      )
       if s then
         push_token(res, subsyntax_info.type, text:sub(i, e))
         current_level = current_level - 1
@@ -135,11 +148,13 @@ function tokenizer.tokenize(incoming_syntax, text, state)
         -- update state if this was a start|end pattern pair
         if type(p.pattern) == "table" then
           state = bit32.replace(state, n, current_level*8, 8)
-          -- If we've found a new subsyntax, bump our level, and set the appropriate variables.
+          -- If we've found a new subsyntax, bump our level, and set the 
+	  -- appropriate variables.
           if p.syntax then
             current_level = current_level + 1
             subsyntax_info = p
-            current_syntax = type(p.syntax) == "table" and p.syntax or syntax.get(p.syntax)
+            current_syntax = type(p.syntax) == "table" and 
+	      p.syntax or syntax.get(p.syntax)
             current_state = 0
           else        
             current_state = n

--- a/data/plugins/language_html.lua
+++ b/data/plugins/language_html.lua
@@ -2,9 +2,11 @@
 local syntax = require "core.syntax"
 
 syntax.add {
-  files = { "%.xml$" },
-  headers = "<%?xml",
+  files = { "%.html?$" },
   patterns = {
+    { pattern = { "<script type=['\"]%a+/javascript['\"]>", "</script>" }, syntax = ".js", type = "function" },
+    { pattern = { "<script>", "</script>" }, syntax = ".js", type = "function" },
+    { pattern = { "<style[^>]*>", "</style>" }, syntax = ".css", type = "function" },
     { pattern = { "<!%-%-", "%-%->" },     type = "comment"  },
     { pattern = { '%f[^>][^<]', '%f[<]' }, type = "normal"   },
     { pattern = { '"', '"', '\\' },        type = "string"   },

--- a/data/plugins/language_html.lua
+++ b/data/plugins/language_html.lua
@@ -4,9 +4,21 @@ local syntax = require "core.syntax"
 syntax.add {
   files = { "%.html?$" },
   patterns = {
-    { pattern = { "<script type=['\"]%a+/javascript['\"]>", "</script>" }, syntax = ".js", type = "function" },
-    { pattern = { "<script>", "</script>" }, syntax = ".js", type = "function" },
-    { pattern = { "<style[^>]*>", "</style>" }, syntax = ".css", type = "function" },
+    { 
+      pattern = { "<script type=['\"]%a+/javascript['\"]>", "</script>" },
+      syntax = ".js", 
+      type = "function" 
+    },
+    { 
+      pattern = { "<script>", "</script>" },
+      syntax = ".js",
+      type = "function"
+    },
+    { 
+      pattern = { "<style[^>]*>", "</style>" },
+      syntax = ".css",
+      type = "function"
+    },
     { pattern = { "<!%-%-", "%-%->" },     type = "comment"  },
     { pattern = { '%f[^>][^<]', '%f[<]' }, type = "normal"   },
     { pattern = { '"', '"', '\\' },        type = "string"   },


### PR DESCRIPTION
Hi!

OK, for my next pull request, I'd like to get nested syntax highlighting working. Whenever I pick up an editor, I check to see whether or not it supports doing something like this; specifically with HTML and CSS.

Now I could probably do this in a plugin, but I think it's a valuable feature to have in the core, so I'll submit it there first, and if it's not appropriate; I'll break it out to a plugin.

Anyway, I've made some preliminary changes, which should allow for this kind of behaviour; however I don't expect this to be merged as-is.

Some things I'd like some pointers on, if anyone's willing to give them:

- I'm unclear about the performance impact of this. I've tried to write it in such a way such that for syntaxes that don't have any subsyntaxes, there's only a few extra if-statements, and not actually that much extra code being run. But I'm not sure how much CPU this kind of thing is taking, so if this is a big concern, I can probably do a bit more to make this more performant (~single if-statement).
- In this vein; even when syntaxes are defined, every time the tokenize call is made, we have to do some bit-wise operations and `syntax.get` calls to resolve the actual syntax we're looking at, if we're using a subsyntax. For very large amounts of lines, this is possibly problematic. If this is a concern, I can work on a caching system to directly reference syntaxes using bits of the state variable, though I'd need some pointers on where to put the caching table.
- Currently, I've just kind of put in the reference to the subsyntaxes as their file extensions. This feels a bit hack-y to me. Ideally there'd be some unique way of referencing syntaxes; some sort of unique handle. If that's the best way to go about it, just say the word, and I'll update both the plugin repository, and the core to contain the extra field. As an alternative, I've also allowed it to just define the syntax in-line, but ideally you'd be able to reference an already extant syntax.
- The system I'm using keeps state as a single numerical variable as it is before these changes (which allows easy comparison, storage, and speed). Lua 5.2 only supports bitwise operations on 32-bit integers, and so that introduces some constraints on the existing syntax engine. Namely, that it adds a limit of of 256 syntax rules (and a maximum depth of 3 subsyntaxes. I can't really think of a language where this'd be a problem, but please let me know if there's a scenario I'm overlooking). I checked the existing plugin repository and the core bundled plugins, and the maximum amount of rules was 40 or so at the highest, so I think this is a reasonable limitation, but if it's not, this could probably be expanded with some changes to how it's architected.
- Would love to know stylistically if things are wrong, or if I'm stepping into any places I shouldn't be, or if there's any functionality that I'm missing.
 
Thank you!

Also, sorry for my git-fu; I'm not 100% certain how to omit the commits that were merged in my previous PR from this branch, but hopefully it shouldn't cause any problems. If it does, let me know, and I'll just re-fork everything and do it correctly from the get-go (I suspect keeping everything as branches, instead of comitting directly my master is the issue here).