### PR TITLE
Made it so that you can continue clicking and still select things.

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -211,10 +211,10 @@ local function mouse_selection(doc, clicks, line1, col1, line2, col2)
   if swap then
     line1, col1, line2, col2 = line2, col2, line1, col1
   end
-  if clicks == 2 then
+  if clicks % 4 == 2 then
     line1, col1 = translate.start_of_word(doc, line1, col1)
     line2, col2 = translate.end_of_word(doc, line2, col2)
-  elseif clicks == 3 then
+  elseif clicks % 4 == 3 then
     if line2 == #doc.lines and doc.lines[#doc.lines] ~= "\n" then
       doc:insert(math.huge, math.huge, "\n")
     end
@@ -233,7 +233,7 @@ function DocView:on_mouse_pressed(button, x, y, clicks)
     return
   end
   if keymap.modkeys["shift"] then
-    if clicks == 1 then
+    if clicks % 2 == 1 then
       local line1, col1 = select(3, self.doc:get_selection())
       local line2, col2 = self:resolve_screen_position(x, y)
       self.doc:set_selection(line2, col2, line1, col1)


### PR DESCRIPTION
Minor fix to change behaviour that irritated me; basically I tend to have spastic clicking habits. Other editors it tends to let me do this cyclically; in Lite, after you've double clicked once, the behaviour just disables itself.

Not major or anything, but I think more inline with what might be expected.