### PR TITLE
Normalized how absolute path names are computed and compared.

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -744,7 +744,7 @@ end
 function core.open_doc(filename)
   if filename then
     -- try to find existing doc for filename
-    local abs_filename = system.absolute_path(filename)
+    local abs_filename = common.home_encode(system.absolute_path(filename))
     for _, doc in ipairs(core.docs) do
       if doc.abs_filename and abs_filename == doc.abs_filename then
         return doc


### PR DESCRIPTION
Closes #172 . If we compare abs_filename, we've gotta use the exact same method of computation as is used to set it, or else we have issues where projects in the home directory start with ~, but the absolute path of the file being opened does not.