### PR TITLE
Added in a validation function which fires before submitting a command.

### DIFF
--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -94,6 +94,15 @@ command.add(nil, {
       core.root_view:open_doc(core.open_doc(common.home_expand(text)))
     end, function (text)
       return common.home_encode_list(common.path_suggest(common.home_expand(text)))
+    end, nil, function(text)
+      local path_stat, err = system.get_file_info(common.home_expand(text))
+      if err then
+        core.error("Cannot open file %q: %q", text, err)
+      elseif path_stat.type == 'dir' then 
+        core.error("Cannot open %q, is a folder", text)
+      else
+        return true
+      end
     end)
   end,
 

--- a/data/core/commandview.lua
+++ b/data/core/commandview.lua
@@ -23,6 +23,7 @@ local default_state = {
   submit = noop,
   suggest = noop,
   cancel = noop,
+  validate = function() return true end
 }
 
 
@@ -97,13 +98,15 @@ end
 function CommandView:submit()
   local suggestion = self.suggestions[self.suggestion_idx]
   local text = self:get_text()
-  local submit = self.state.submit
-  self:exit(true)
-  submit(text, suggestion)
+  if self.state.validate(text) then
+    local submit = self.state.submit
+    self:exit(true)
+    submit(text, suggestion)
+  end
 end
 
 
-function CommandView:enter(text, submit, suggest, cancel)
+function CommandView:enter(text, submit, suggest, cancel, validate)
   if self.state ~= default_state then
     return
   end
@@ -111,6 +114,7 @@ function CommandView:enter(text, submit, suggest, cancel)
     submit = submit or noop,
     suggest = suggest or noop,
     cancel = cancel or noop,
+    validate = validate or function() return true end
   }
   core.set_active_view(self)
   self:update_suggestions()


### PR DESCRIPTION
Wrote a small patch to fix a minor irritant; found it annoying when trying to open something, hitting enter, only to be told I'd selected a directory, and then have to go through the whole process again. 

This basically just allows you to preempt the actual submission, and to throw errors if necessary, rather than forcing a close.