### PR TITLE
Support for changing fonts per syntax group

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,19 @@ Lite XL is following closely [rxi/lite](https://github.com/rxi/lite) but with so
 
 This files document the changes done in Lite XL for each release.
 
+### 1.16.9
+
+[#126](https://github.com/franko/lite-xl/issues/126): Implemented changing fonts per syntax group.
+Example user module snippet that makes all comments italic:
+
+```lua
+local style = require "core.style"
+
+-- italic.ttf must be provided by the user
+local italic = renderer.font.load("italic.ttf", 14)
+style.syntax_fonts["comment"] = italic
+```
+
 ### 1.16.6
 
 Implement a system to check the compatibility of plugins by checking a release tag.

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -145,7 +145,7 @@ function DocView:get_col_x_offset(line, col)
   local column = 1
   local xoffset = 0
   for _, type, text in self.doc.highlighter:each_token(line) do
-    local font = style.fonts[type] or default_font
+    local font = style.syntax_fonts[type] or default_font
     for char in common.utf8_chars(text) do
       if column == col then
         return xoffset / font:subpixel_scale()
@@ -167,7 +167,7 @@ function DocView:get_x_offset_col(line, x)
   local subpixel_scale = default_font:subpixel_scale()
   local x_subpixel = subpixel_scale * x + subpixel_scale / 2
   for _, type, text in self.doc.highlighter:each_token(line) do
-    local font = style.fonts[type] or default_font
+    local font = style.syntax_fonts[type] or default_font
     for char in common.utf8_chars(text) do
       local w = font:get_width_subpixel(char)
       if xoffset >= subpixel_scale * x then
@@ -329,7 +329,7 @@ function DocView:draw_line_text(idx, x, y)
   local tx, ty = subpixel_scale * x, y + self:get_line_text_y_offset()
   for _, type, text in self.doc.highlighter:each_token(idx) do
     local color = style.syntax[type]
-    local font = style.fonts[type] or default_font
+    local font = style.syntax_fonts[type] or default_font
     if config.draw_whitespace then
       tx = renderer.draw_text_subpixel(font, text, tx, ty, color, core.replacements, style.syntax.comment)
     else

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -159,7 +159,6 @@ function DocView:get_col_x_offset(line, col)
 end
 
 
--- testing italic testing 123412412093283092183
 function DocView:get_x_offset_col(line, x)
   local line_text = self.doc.lines[line]
 

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -308,11 +308,12 @@ end
 
 
 function DocView:draw_line_text(idx, x, y)
-  local font = self:get_font()
-  local subpixel_scale = font:subpixel_scale()
+  local default_font = self:get_font()
+  local subpixel_scale = default_font:subpixel_scale()
   local tx, ty = subpixel_scale * x, y + self:get_line_text_y_offset()
   for _, type, text in self.doc.highlighter:each_token(idx) do
     local color = style.syntax[type]
+    local font = style.fonts[type] or default_font
     if config.draw_whitespace then
       tx = renderer.draw_text_subpixel(font, text, tx, ty, color, core.replacements, style.syntax.comment)
     else

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -141,45 +141,46 @@ end
 
 
 function DocView:get_col_x_offset(line, col)
-  local text = self.doc.lines[line]
-  if not text then return 0 end
-
-  local column = 1
-  local x_subpixel = 0
   local default_font = self:get_font()
-  for _, type, token_text in self.doc.highlighter:each_token(line) do
+  local column = 1
+  local xoffset = 0
+  for _, type, text in self.doc.highlighter:each_token(line) do
     local font = style.fonts[type] or default_font
-    for char in common.utf8_chars(token_text) do
+    for char in common.utf8_chars(text) do
       if column == col then
-        return x_subpixel / font:subpixel_scale()
+        return xoffset / font:subpixel_scale()
       end
-      x_subpixel = x_subpixel + font:get_width_subpixel(char)
-      column = column + 1
+      xoffset = xoffset + font:get_width_subpixel(char)
+      column = column + #char
     end
   end
 
-  return x_subpixel / default_font:subpixel_scale()
+  return xoffset / default_font:subpixel_scale()
 end
 
 
 -- testing italic testing 123412412093283092183
 function DocView:get_x_offset_col(line, x)
-  local text = self.doc.lines[line]
+  local line_text = self.doc.lines[line]
 
   local xoffset, last_i, i = 0, 1, 1
-  local subpixel_scale = self:get_font():subpixel_scale()
+  local default_font = self:get_font()
+  local subpixel_scale = default_font:subpixel_scale()
   local x_subpixel = subpixel_scale * x + subpixel_scale / 2
-  for char in common.utf8_chars(text) do
-    local w = self:get_font():get_width_subpixel(char)
-    if xoffset >= subpixel_scale * x then
-      return (xoffset - x_subpixel > w / 2) and last_i or i
+  for _, type, text in self.doc.highlighter:each_token(line) do
+    local font = style.fonts[type] or default_font
+    for char in common.utf8_chars(text) do
+      local w = font:get_width_subpixel(char)
+      if xoffset >= subpixel_scale * x then
+        return (xoffset - x_subpixel > w / 2) and last_i or i
+      end
+      xoffset = xoffset + w
+      last_i = i
+      i = i + #char
     end
-    xoffset = xoffset + w
-    last_i = i
-    i = i + #char
   end
 
-  return #text
+  return #line_text
 end
 
 

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -143,15 +143,31 @@ end
 function DocView:get_col_x_offset(line, col)
   local text = self.doc.lines[line]
   if not text then return 0 end
-  return self:get_font():get_width(text:sub(1, col - 1))
+
+  local column = 1
+  local x_subpixel = 0
+  local default_font = self:get_font()
+  for _, type, token_text in self.doc.highlighter:each_token(line) do
+    local font = style.fonts[type] or default_font
+    for char in common.utf8_chars(token_text) do
+      if column == col then
+        return x_subpixel / font:subpixel_scale()
+      end
+      x_subpixel = x_subpixel + font:get_width_subpixel(char)
+      column = column + 1
+    end
+  end
+
+  return x_subpixel / default_font:subpixel_scale()
 end
 
 
+-- testing italic testing 123412412093283092183
 function DocView:get_x_offset_col(line, x)
   local text = self.doc.lines[line]
 
   local xoffset, last_i, i = 0, 1, 1
-  local subpixel_scale = self:get_font():subpixel_scale();
+  local subpixel_scale = self:get_font():subpixel_scale()
   local x_subpixel = subpixel_scale * x + subpixel_scale / 2
   for char in common.utf8_chars(text) do
     local w = self:get_font():get_width_subpixel(char)

--- a/data/core/style.lua
+++ b/data/core/style.lua
@@ -58,6 +58,10 @@ style.syntax["operator"] = { common.color "#93DDFA" }
 style.syntax["function"] = { common.color "#93DDFA" }
 
 -- This can be used to override fonts per syntax group.
+-- The syntax highlighter will take existing values from this table and
+-- override style.code_font on a per-token basis, so you can choose to eg.
+-- render comments in an italic font if you want to.
 style.fonts = {}
+-- style.fonts["comment"] = renderer.font.load(path_to_font, size_of_font, rendering_options)
 
 return style

--- a/data/core/style.lua
+++ b/data/core/style.lua
@@ -61,7 +61,7 @@ style.syntax["function"] = { common.color "#93DDFA" }
 -- The syntax highlighter will take existing values from this table and
 -- override style.code_font on a per-token basis, so you can choose to eg.
 -- render comments in an italic font if you want to.
-style.fonts = {}
--- style.fonts["comment"] = renderer.font.load(path_to_font, size_of_font, rendering_options)
+style.syntax_fonts = {}
+-- style.syntax_fonts["comment"] = renderer.font.load(path_to_font, size_of_font, rendering_options)
 
 return style

--- a/data/core/style.lua
+++ b/data/core/style.lua
@@ -57,4 +57,7 @@ style.syntax["string"] = { common.color "#f7c95c" }
 style.syntax["operator"] = { common.color "#93DDFA" }
 style.syntax["function"] = { common.color "#93DDFA" }
 
+-- This can be used to override fonts per syntax group.
+style.fonts = {}
+
 return style


### PR DESCRIPTION
Implements part of #126.

@franko I'm not sure whether you want to include this in a 1.16 patch or 1.17 altogether, so I didn't include a changelog entry yet.