### PR TITLE
Fix creating a new file

### DIFF
--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -229,7 +229,7 @@ end
 
 
 function common.normalize_path(filename)
-  if PATHSEP == '\\' then
+  if filename and PATHSEP == '\\' then
     filename = filename:gsub('[/\\]', '\\')
     local drive, rem = filename:match('^([a-zA-Z])(:.*)')
     return drive and drive:upper() .. rem or filename


### PR DESCRIPTION
Windows 10, Lite XL 1.16.8
When creating a new file, the following error occurs:
```
common.lua:233: attempt to index local 'filename' (a nil value)
```
