### PR TITLE
Update C Language file

### DIFF
--- a/data/plugins/language_c.lua
+++ b/data/plugins/language_c.lua
@@ -7,7 +7,6 @@ syntax.add {
   patterns = {
     { pattern = "//.-\n",               type = "comment"  },
     { pattern = { "/%*", "%*/" },       type = "comment"  },
-    { pattern = { "#", "[^\\]\n" },     type = "comment"  },
     { pattern = { '"', '"', '\\' },     type = "string"   },
     { pattern = { "'", "'", '\\' },     type = "string"   },
     { pattern = "-?0x%x+",              type = "number"   },
@@ -15,7 +14,7 @@ syntax.add {
     { pattern = "-?%.?%d+f?",           type = "number"   },
     { pattern = "[%+%-=/%*%^%%<>!~|&]", type = "operator" },
     { pattern = "[%a_][%w_]*%f[(]",     type = "function" },
-    { pattern = "[%a_][%w_]*",          type = "symbol"   },
+    { pattern = "#?[%a_][%w_]*",        type = "symbol"   },
   },
   symbols = {
     ["if"]       = "keyword",
@@ -29,7 +28,7 @@ syntax.add {
     ["continue"] = "keyword",
     ["return"]   = "keyword",
     ["goto"]     = "keyword",
-    ["struct"]   = "keyword",
+    ["struct"]   = "keyword2",
     ["union"]    = "keyword",
     ["typedef"]  = "keyword",
     ["enum"]     = "keyword",
@@ -55,6 +54,17 @@ syntax.add {
     ["true"]     = "literal",
     ["false"]    = "literal",
     ["NULL"]     = "literal",
+    ["#include"] = "keyword",
+    ["#if"] = "keyword",
+    ["#ifdef"] = "keyword",
+    ["#ifndef"] = "keyword",
+    ["#else"] = "keyword",
+    ["#elseif"] = "keyword",
+    ["#endif"] = "keyword",
+    ["#define"] = "keyword",
+    ["#warning"] = "keyword",
+    ["#error"] = "keyword",
+    ["#pragma"] = "keyword",
   },
 }
 


### PR DESCRIPTION
comments in C are never done with a # character so that pattern is removed
the symbol pattern is extended to support for preprocessor directives
a list of some commonly used preprocessor as well as some integer types were added to the list of symbols