### PR TITLE
Unified open and saving style.

### DIFF
--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -88,7 +88,8 @@ command.add(nil, {
   ["core:open-file"] = function()
     local view = core.active_view
     if view.doc and view.doc.abs_filename then
-      core.command_view:set_text(common.home_encode(view.doc.abs_filename))
+      local dirname, filename = view.doc.abs_filename:match("(.*)[/\\](.+)$")
+      core.command_view:set_text(core.normalize_to_project_dir(dirname) .. PATHSEP)
     end
     core.command_view:enter("Open File", function(text)
       core.root_view:open_doc(core.open_doc(common.home_expand(text)))

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -299,6 +299,9 @@ local commands = {
   ["doc:save-as"] = function()
     if doc().filename then
       core.command_view:set_text(doc().filename)
+    elseif core.last_active_view then
+      local dirname, filename = core.last_active_view.doc.abs_filename:match("(.*)[/\\](.+)$")
+      core.command_view:set_text(core.normalize_to_project_dir(dirname) .. PATHSEP)
     end
     core.command_view:enter("Save As", function(filename)
       save(common.home_expand(filename))


### PR DESCRIPTION
So, I know a while back I made that initial pull request to include the directory for the file that's currently being looked at. I noticed this behaviour is somewhat at-odds with how the save function works for new files.

I think we should make the following changes:

- Change open file's start directory to be normalised to the project directory. This would make it more in line with what happens if you save a file, or if you move to open a file with no file tab selected. Still just as useful, but keeps the same style.
- For saving a new file, start in the same directory as the last tab that we had selected (we already have this in `core.last_active_view`.

Find it makes a lot easier to save/load things.