### PR TITLE
Fix Partial Unindents

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -45,15 +45,22 @@ local function insert_at_start_of_selected_lines(text, skip_empty)
   doc():set_selection(line1, col1 + #text, line2, col2 + #text, swap)
 end
 
+ 
 
-local function remove_from_start_of_selected_lines(text, skip_empty)
+local function remove_from_start_of_selected_lines(text, skip_empty, remove_partial)
   local line1, col1, line2, col2, swap = doc_multiline_selection(true)
   for line = line1, line2 do
     local line_text = doc().lines[line]
-    if  line_text:sub(1, #text) == text
-    and (not skip_empty or line_text:find("%S"))
-    then
-      doc():remove(line, 1, line, #text + 1)
+    for i = #text, 1, -1 do
+      if line_text:sub(1, i) == text:sub(1, i)
+        and (not skip_empty or line_text:find("%S"))
+      then
+        doc():remove(line, 1, line, i + 1)
+        break
+      end
+      if not remove_partial then
+        break
+      end
     end
   end
   doc():set_selection(line1, col1 - #text, line2, col2 - #text, swap)
@@ -193,7 +200,7 @@ local commands = {
 
   ["doc:unindent"] = function()
     local text = get_indent_string()
-    remove_from_start_of_selected_lines(text)
+    remove_from_start_of_selected_lines(text, false, true)
   end,
 
   ["doc:duplicate-lines"] = function()


### PR DESCRIPTION
Made it so that when you deindent, even if you have a line that's a portion of your delimiter (i.e. you have a 3 spaces at the beginning of a line, but the document has a tab style of 4 spaces, it'll still remove those 3). This is more in line with other editors.