### PR TITLE
Tokenizer cleanup

### DIFF
--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -136,7 +136,7 @@ function tokenizer.tokenize(incoming_syntax, text, state)
   -- Should be used to set the state variable. Don't modify it directly.
   local function set_subsyntax_state(pattern_idx)
     current_state = pattern_idx
-    state = bit32.replace(state, new_state, current_level*8, 8)
+    state = bit32.replace(state, pattern_idx, current_level*8, 8)
   end
   
   

--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -128,14 +128,14 @@ function tokenizer.tokenize(incoming_syntax, text, state)
   
   -- current_syntax : the syntax we're currently in.
   -- subsyntax_info : info about the delimiters of this subsyntax.
-  -- current_state  : the index rule we're on for this subsyntax.
+  -- current_state  : the index of the pattern we're on for this syntax.
   -- current_level  : how many subsyntaxes deep we are.
   local current_syntax, subsyntax_info, current_state, current_level =
     retrieve_syntax_state(incoming_syntax, state)
   
   -- Should be used to set the state variable. Don't modify it directly.
-  local function set_subsyntax_state(new_state)
-    current_state = new_state
+  local function set_subsyntax_state(pattern_idx)
+    current_state = pattern_idx
     state = bit32.replace(state, new_state, current_level*8, 8)
   end
   
@@ -153,7 +153,8 @@ function tokenizer.tokenize(incoming_syntax, text, state)
       set_subsyntax_state(0)
       current_level = current_level - 1
       set_subsyntax_state(0)
-      current_syntax, subsyntax_info, current_state, current_level = retrieve_syntax_state(incoming_syntax, state)
+      current_syntax, subsyntax_info, current_state, current_level = 
+        retrieve_syntax_state(incoming_syntax, state)
   end
   
   while i <= #text do

--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -144,17 +144,18 @@ function tokenizer.tokenize(incoming_syntax, text, state)
     set_subsyntax_pattern_idx(pattern_idx)
     current_level = current_level + 1
     subsyntax_info = entering_syntax
-    current_syntax = type(entering_syntax) == "table" and
+    current_syntax = type(entering_syntax.syntax) == "table" and
       entering_syntax.syntax or syntax.get(entering_syntax.syntax)
     current_pattern_idx = 0
   end
   
   local function pop_subsyntax()
-      set_subsyntax_pattern_idx(0)
-      current_level = current_level - 1
-      set_subsyntax_pattern_idx(0)
-      current_syntax, subsyntax_info, current_pattern_idx, current_level = 
-        retrieve_syntax_state(incoming_syntax, state)
+    set_subsyntax_pattern_idx(0)
+    current_level = current_level - 1
+    set_subsyntax_pattern_idx(0)
+    current_syntax, subsyntax_info, current_pattern_idx, current_level = 
+      retrieve_syntax_state(incoming_syntax, state)
+  
   end
   
   while i <= #text do

--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -140,7 +140,8 @@ function tokenizer.tokenize(incoming_syntax, text, state)
   end
   
   
-  local function push_subsyntax(entering_syntax)
+  local function push_subsyntax(entering_syntax, pattern_idx)
+    set_subsyntax_state(pattern_idx)
     current_level = current_level + 1
     subsyntax_info = entering_syntax
     current_syntax = type(entering_syntax) == "table" and
@@ -227,10 +228,11 @@ function tokenizer.tokenize(incoming_syntax, text, state)
 
         -- update state if this was a start|end pattern pair
         if type(p.pattern) == "table" then
-          set_subsyntax_state(n)
+          -- If we have a subsyntax, push that onto the subsyntax stack.
           if p.syntax then
-            -- If we have a subsyntax, push that onto the subsyntax stack.
-            push_subsyntax(p)
+            push_subsyntax(p, n)
+          else          
+            set_subsyntax_state(n)
           end
         end
         

--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -134,14 +134,14 @@ function tokenizer.tokenize(incoming_syntax, text, state)
     retrieve_syntax_state(incoming_syntax, state)
   
   -- Should be used to set the state variable. Don't modify it directly.
-  local function set_subsyntax_state(pattern_idx)
+  local function set_subsyntax_pattern_idx(pattern_idx)
     current_pattern_idx = pattern_idx
     state = bit32.replace(state, pattern_idx, current_level*8, 8)
   end
   
   
   local function push_subsyntax(entering_syntax, pattern_idx)
-    set_subsyntax_state(pattern_idx)
+    set_subsyntax_pattern_idx(pattern_idx)
     current_level = current_level + 1
     subsyntax_info = entering_syntax
     current_syntax = type(entering_syntax) == "table" and
@@ -150,9 +150,9 @@ function tokenizer.tokenize(incoming_syntax, text, state)
   end
   
   local function pop_subsyntax()
-      set_subsyntax_state(0)
+      set_subsyntax_pattern_idx(0)
       current_level = current_level - 1
-      set_subsyntax_state(0)
+      set_subsyntax_pattern_idx(0)
       current_syntax, subsyntax_info, current_pattern_idx, current_level = 
         retrieve_syntax_state(incoming_syntax, state)
   end
@@ -189,7 +189,7 @@ function tokenizer.tokenize(incoming_syntax, text, state)
       if cont then
         if s then
           push_token(res, p.type, text:sub(i, e))
-          set_subsyntax_state(0)
+          set_subsyntax_pattern_idx(0)
           i = e + 1
         else
           push_token(res, p.type, text:sub(i))
@@ -232,7 +232,7 @@ function tokenizer.tokenize(incoming_syntax, text, state)
           if p.syntax then
             push_subsyntax(p, n)
           else          
-            set_subsyntax_state(n)
+            set_subsyntax_pattern_idx(n)
           end
         end
         


### PR DESCRIPTION
Added in a bunch more comments, and reframed how operations functions in more standard comp sci. terms (e.g. a stack), and moved out bitwise code to named functions that should hopefully give a bit better idea of what it's doing.