### PR TITLE
Indent Enhancements

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -83,7 +83,7 @@ local function get_line_indent(line, rnd_up)
   local soft_tab = string.rep(" ", config.indent_size)
   if config.tab_type == "hard" then
     local indent = line:sub(1, e):gsub(soft_tab, "\t")
-    return e, rnd_up and indent:gsub(" +", "\t") or indent:gsub(" ", "")
+    return e, indent:gsub(" +", rnd_up and "\t" or "")
   else
     local indent = e and line:sub(1, e):gsub("\t", soft_tab) or ""
     local number = #indent / #soft_tab
@@ -92,6 +92,16 @@ local function get_line_indent(line, rnd_up)
   end
 end
 
+-- un/indents text; behaviour varies based on selection and un/indent.
+-- * if there's a selection, it will stay static around the 
+--   text for both indenting and unindenting.
+-- * if you are in the beginning whitespace of a line, and are indenting, the 
+--   cursor will insert the exactly appropriate amount of spaces, and jump the
+--   cursor to the beginning of first non whitespace characters
+-- * if you are not in the beginning whitespace of a line, and you indent, it 
+--   inserts the appropriate whitespace, as if you typed them normally.
+-- * if you are unindenting, the cursor will jump to the start of the line,
+--   and remove the appropriate amount of spaces (or a tab).
 local function indent_text(unindent)
   local text = get_indent_string()
   local line1, col1, line2, col2, swap = doc_multiline_selection(true)

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -104,7 +104,7 @@ end
 --   and remove the appropriate amount of spaces (or a tab).
 local function indent_text(unindent)
   local text = get_indent_string()
-  local line1, col1, line2, col2, swap = doc_multiline_selection(true)
+  local line1, col1, line2, col2, swap = doc():get_selection(true)
   local _, se = doc().lines[line1]:find("^%s+")
   local in_beginning_whitespace = col1 == 1 or (se and col1 <= se + 1)
   if unindent or doc():has_selection() or in_beginning_whitespace then

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -45,17 +45,15 @@ local function insert_at_start_of_selected_lines(text, skip_empty)
   doc():set_selection(line1, col1 + #text, line2, col2 + #text, swap)
 end
 
- 
 
 local function remove_from_start_of_selected_lines(text, skip_empty)
   local line1, col1, line2, col2, swap = doc_multiline_selection(true)
   for line = line1, line2 do
     local line_text = doc().lines[line]
-    if line_text:sub(1, #text) == text:sub(1, #text)
-      and (not skip_empty or line_text:find("%S"))
+    if  line_text:sub(1, #text) == text
+    and (not skip_empty or line_text:find("%S"))
     then
       doc():remove(line, 1, line, #text + 1)
-      break
     end
   end
   doc():set_selection(line1, col1 - #text, line2, col2 - #text, swap)

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -111,9 +111,7 @@ local function indent_text(unindent)
     local l1d, l2d = #doc().lines[line1], #doc().lines[line2]
     for line = line1, line2 do
       local e, rnded = get_line_indent(doc().lines[line], unindent)
-      if e then
-        doc():remove(line, 1, line, e + 1)
-      end
+      doc():remove(line, 1, line, (e or 0) + 1)
       doc():insert(line, 1, 
         unindent and rnded:sub(1, #rnded - #text) or rnded .. text)
     end

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -80,7 +80,7 @@ local function get_line_indent(line, rnd_up)
   local _, e = line:find("^[ \t]+")
   local soft_tab = string.rep(" ", config.indent_size)
   if config.tab_type == "hard" then
-    local indent = line:sub(1, e):gsub(soft_tab, "\t")
+    local indent = e and line:sub(1, e):gsub(soft_tab, "\t") or ""
     return e, indent:gsub(" +", rnd_up and "\t" or "")
   else
     local indent = e and line:sub(1, e):gsub("\t", soft_tab) or ""

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -79,7 +79,7 @@ end
 -- returns the size of the original indent, and the indent 
 -- in your config format, rounded either up or down
 local function get_line_indent(line, rnd_up)
-  local _, e = line:find("^%s+")
+  local _, e = line:find("^[ \t]+")
   local soft_tab = string.rep(" ", config.indent_size)
   if config.tab_type == "hard" then
     local indent = line:sub(1, e):gsub(soft_tab, "\t")
@@ -105,13 +105,15 @@ end
 local function indent_text(unindent)
   local text = get_indent_string()
   local line1, col1, line2, col2, swap = doc():get_selection(true)
-  local _, se = doc().lines[line1]:find("^%s+")
+  local _, se = doc().lines[line1]:find("^[ \t]+")
   local in_beginning_whitespace = col1 == 1 or (se and col1 <= se + 1)
   if unindent or doc():has_selection() or in_beginning_whitespace then
     local l1d, l2d = #doc().lines[line1], #doc().lines[line2]
     for line = line1, line2 do
       local e, rnded = get_line_indent(doc().lines[line], unindent)
-      doc():remove(line, 1, line, (e or 0) + 1)
+      if e then
+        doc():remove(line, 1, line, e + 1)
+      end
       doc():insert(line, 1, 
         unindent and rnded:sub(1, #rnded - #text) or rnded .. text)
     end


### PR DESCRIPTION
Reverted back to the original indentation scheme, and then added in two new functions.

`get_line_indent` normalizes the line to use tabs, or spaces, and then rounds the line either up or down to the appropriate number of spaces.

`indent_text` either indents or unindents the text selected. If there's a block of text selected, the selection will keep static around the text for both indenting and unindenting. If nothing is selected, then the following happens:

- if you are in the beginning whitespace of a line, and are indenting, the cursor will insert the exactly appropriate amount of spaces (so if you have an indent_size of 3, and you have a total of 8 spaces in the line, it'll add exactly 1 space), and jump the cursor to the beginning of first non whitespace characters (in this example, character 9).
- if you are not in the beginning whitespace of a line, and you indent, it inserts a tab, or `config.indent_size` spaces, as if you typed them normally.
- if you are unindenting, the cursor will jump to the start of the line, and remove the appropriate amount of spaces (or a tab).

Please give it a whirl, and let me know what you think, or if you hit any bugs.