### PR TITLE
Added ability to register on_doc_close hooks.

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -563,6 +563,22 @@ function core.on_doc_save(filename)
   end
 end
 
+
+core.doc_close_hooks = {}
+function core.add_close_hook(fn)
+  core.doc_close_hooks[#core.doc_close_hooks + 1] = fn
+end
+
+
+function core.on_doc_close(doc)
+  core.log_quiet("Closed doc \"%s\"", doc:get_name())
+
+  for _, hook in ipairs(core.doc_close_hooks) do
+    hook(doc)
+  end
+end
+
+
 local function quit_with_function(quit_fn, force)
   if force then
     delete_temp_files()
@@ -918,7 +934,7 @@ function core.step()
     local doc = core.docs[i]
     if #core.get_views_referencing_doc(doc) == 0 then
       table.remove(core.docs, i)
-      core.log_quiet("Closed doc \"%s\"", doc:get_name())
+      core.on_doc_close(doc)
     end
   end
 


### PR DESCRIPTION
Currently there is an easy way to register functions for doc opening, saving, editing, etc... but not if wanting to register an event when a document gets closed. As part of the LSP plugin effort this commit introduces the option of registering hooks that get triggered each time a document is saved so we can easily send the [textDocument/didClose](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_didClose) notification to the LSP server from the LSP plugin.