### PR TITLE
Avoid to restore window size when maximized

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -18,7 +18,7 @@ local core = {}
 local function load_session()
   local ok, t = pcall(dofile, USERDIR .. "/session.lua")
   if ok then
-    return t.recents, t.window
+    return t.recents, t.window, t.window_mode
   end
   return {}
 end
@@ -29,6 +29,7 @@ local function save_session()
   if fp then
     fp:write("return {recents=", common.serialize(core.recent_projects),
       ", window=", common.serialize(table.pack(system.get_window_size())),
+      ", window_mode=", common.serialize(system.get_window_mode()),
       "}\n")
     fp:close()
   end
@@ -370,9 +371,11 @@ function core.init()
   end
 
   do
-    local recent_projects, window_position = load_session()
-    if window_position then
+    local recent_projects, window_position, window_mode = load_session()
+    if window_mode == "normal" then
       system.set_window_size(table.unpack(window_position))
+    else
+      system.set_window_mode("maximized")
     end
     core.recent_projects = recent_projects
   end


### PR DESCRIPTION
I started trying to restore any saved window_mode but thinking on it a minimized window when starting an application doesn't makes much sense in the end, and when restoring in fullscreen it adds some window buttons which looks strange (see screenshot below). So I decided to save the states and if normal restores the saved window_position, anything else loads maximized, including if the `session.lua` file is missing (no state, no position). Fixes #219.

![immagine](https://user-images.githubusercontent.com/1171962/119875668-4eb44980-bf27-11eb-9dd4-936c9fe4b1cd.png)
