### PR TITLE
Fixed build, missing reproc dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build*
 subprojects/lua
 subprojects/libagg
 subprojects/reproc
+lite

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 cflags+="-Wall -O3 -g -std=gnu11 -fno-strict-aliasing -Isrc -Ilib/font_renderer"
 cflags+=" $(pkg-config --cflags lua5.2) $(sdl2-config --cflags)"
 lflags="-static-libgcc -static-libstdc++"
-for package in libagg freetype2 lua5.2 x11 libpcre2-8; do
+for package in libagg freetype2 lua5.2 x11 libpcre2-8 reproc; do
   lflags+=" $(pkg-config --libs $package)"
 done
 lflags+=" $(sdl2-config --libs) -lm"


### PR DESCRIPTION
I'm not sure if `reproc` can be added properly via `pkg-config` like this, but it fixes a build error because the missing link, plus I also added the binary to `.gitignore` when building with the `build.sh` script.