### PR TITLE
Add secondary fullscreen bind

### DIFF
--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -108,6 +108,7 @@ keymap.add_direct {
   ["ctrl+shift+c"] = "core:change-project-folder",
   ["ctrl+shift+o"] = "core:open-project-folder",
   ["alt+return"] = "core:toggle-fullscreen",
+  ["f11"] = "core:toggle-fullscreen",
 
   ["alt+shift+j"] = "root:split-left",
   ["alt+shift+l"] = "root:split-right",

--- a/doc/default-keymap.md
+++ b/doc/default-keymap.md
@@ -11,6 +11,7 @@
 | ctrl+shift+c          | core:change-project-folder          |
 | ctrl+shift+o          | core:open-project-folder            |
 | alt+return            | core:toggle-fullscreen              |
+| f11                   | core:toggle-fullscreen              |
 | alt+shift+j           | root:split-left                     |
 | alt+shift+l           | root:split-right                    |
 | alt+shift+i           | root:split-up                       |


### PR DESCRIPTION
F11 is a very common bind for full screen and I think more people are used to it than ALT+Enter. I didn't remove the other bind, just added a second one.