### PR TITLE
Plugin precedence

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -639,24 +639,28 @@ function core.load_plugins()
     userdir = {dir = USERDIR, plugins = {}},
     datadir = {dir = DATADIR, plugins = {}},
   }
-  for _, root_dir in ipairs {USERDIR, DATADIR} do
+  local files = {}
+  for _, root_dir in ipairs {DATADIR, USERDIR} do
     local plugin_dir = root_dir .. "/plugins"
-    local files = system.list_dir(plugin_dir)
-    for _, filename in ipairs(files or {}) do
-      local basename = filename:match("(.-)%.lua$") or filename
-      local version_match = check_plugin_version(plugin_dir .. '/' .. filename)
-      if not version_match then
-        core.log_quiet("Version mismatch for plugin %q from %s", basename, plugin_dir)
-        local ls = refused_list[root_dir == USERDIR and 'userdir' or 'datadir'].plugins
-        ls[#ls + 1] = filename
-      end
-      if version_match and config[basename] ~= false then
-        local modname = "plugins." .. basename
-        local ok = core.try(require, modname)
-        if ok then core.log_quiet("Loaded plugin %q from %s", basename, plugin_dir) end
-        if not ok then
-          no_errors = false
-        end
+    for _, filename in ipairs(system.list_dir(plugin_dir) or {}) do
+      files[filename] = plugin_dir -- user plugins will always replace system plugins
+    end
+  end
+
+  for filename, plugin_dir in pairs(files) do
+    local basename = filename:match("(.-)%.lua$") or filename
+    local version_match = check_plugin_version(plugin_dir .. '/' .. filename)
+    if not version_match then
+      core.log_quiet("Version mismatch for plugin %q from %s", basename, plugin_dir)
+      local ls = refused_list[root_dir == USERDIR and 'userdir' or 'datadir'].plugins
+      ls[#ls + 1] = filename
+    end
+    if version_match and config[basename] ~= false then
+      local modname = "plugins." .. basename
+      local ok = core.try(require, modname)
+      if ok then core.log_quiet("Loaded plugin %q from %s", basename, plugin_dir) end
+      if not ok then
+        no_errors = false
       end
     end
   end


### PR DESCRIPTION
When you have the same plugin in `USERDIR` and `DATADIR`, lite-xl loads them twice. The correct behavior is lite-xl loads the `USERDIR` plugin instead of `DATADIR`.