### PR TITLE
Flush the SDL_QUIT event when Cmd+W is detected in SDL_KEYDOWN as well

### DIFF
--- a/src/api/system.c
+++ b/src/api/system.c
@@ -152,6 +152,14 @@ top:
       return 4;
 
     case SDL_KEYDOWN:
+#ifdef __APPLE__
+      /* on macos 11.2.3 with sdl 2.0.14 the keyup handler for cmd+w below
+      ** was not enough. Maybe the quit event started to be triggered from the
+      ** keydown handler? In any case, flushing the quit event here too helped. */
+      if ((e.key.keysym.sym == SDLK_w) && (e.key.keysym.mod & KMOD_GUI)) {
+        SDL_FlushEvent(SDL_QUIT);
+      }
+#endif
       lua_pushstring(L, "keypressed");
       lua_pushstring(L, key_name(buf, e.key.keysym.sym));
       return 2;
@@ -162,8 +170,7 @@ top:
       ** we want to flush this event and let the keymapper
       ** handle this key combination.
       ** Thanks to mathewmariani, taken from his lite-macos github repository. */
-      if ((e.key.keysym.sym == SDLK_w) && (e.key.keysym.mod & KMOD_GUI))
-      {
+      if ((e.key.keysym.sym == SDLK_w) && (e.key.keysym.mod & KMOD_GUI)) {
         SDL_FlushEvent(SDL_QUIT);
       }
 #endif


### PR DESCRIPTION
On macos 11.2.3 with sdl 2.0.14 the keyup handler for cmd+w was not enough. Maybe the quit event started to be triggered from the keydown handler? In any case, flushing the quit event there too helped.

Attempts to fix #238.