### PR TITLE
Enable lite-xl to be started from a symlink to the deployed binary

### DIFF
--- a/src/bundle_open.m
+++ b/src/bundle_open.m
@@ -4,8 +4,25 @@
 void set_macos_bundle_resources(lua_State *L)
 { @autoreleasepool
 {
-    NSString* resource_path = [[NSBundle mainBundle] resourcePath];
-    lua_pushstring(L, [resource_path UTF8String]);
+    /* Use resolved executablePath instead of resourcePath to allow lanching
+       the lite-xl binary via a symlink, like typically done by Homebrew:
+
+    /usr/local/bin/lite-xl -> /Applications/lite-xl.app/Contents/MacOS/lite-xl
+
+       The resourcePath returns /usr/local in this case instead of
+       /Applications/lite-xl.app/Contents/Resources, which makes later
+       access to the resource files fail. Resolving the symlink to the
+       executable and then the relative path to the expected directory
+       Resources is a workaround for starting the application from both
+       the launcher directly and the command line via the symlink.
+     */
+    NSString* executable_path = [[NSBundle mainBundle] executablePath];
+    char resolved_path[PATH_MAX + 16 + 1];
+    realpath([executable_path UTF8String], resolved_path);
+    strcat(resolved_path, "/../../Resources");
+    char resource_path[PATH_MAX + 1];
+    realpath(resolved_path, resource_path);
+    lua_pushstring(L, resource_path);
     lua_setglobal(L, "MACOS_RESOURCES");
 }}
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <SDL.h>
 #include "api/api.h"
 #include "rencache.h"
@@ -62,8 +63,13 @@ static void get_exe_filename(char *buf, int sz) {
   int len = readlink(path, buf, sz - 1);
   buf[len] = '\0';
 #elif __APPLE__
+  /* use realpath to resolve a symlink if the process was launched from one.
+  ** This happens when Homebrew installs a cack and creates a symlink in
+  ** /usr/loca/bin for launching the executable from the command line. */
   unsigned size = sz;
-  _NSGetExecutablePath(buf, &size);
+  char exepath[size];
+  _NSGetExecutablePath(exepath, &size);
+  realpath(exepath, buf);
 #else
   strcpy(buf, "./lite");
 #endif


### PR DESCRIPTION
Use resolved executablePath instead of resourcePath to allow lanching
the lite-xl binary via a symlink, like typically done by Homebrew:

/usr/local/bin/lite-xl -> /Applications/lite-xl.app/Contents/MacOS/lite-xl

The resourcePath returns /usr/local in this case instead of
/Applications/lite-xl.app/Contents/Resources, which makes later
access to the resource files fail. Resolving the symlink to the
executable and then the relative path to the expected directory
Resources is a workaround for starting the application from both
the launcher directly and the command line via the symlink.

Attempts to fix #250.