### PR TITLE
Fix: broken build-packages.sh

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -32,9 +32,7 @@ foreach data_module : ['core', 'fonts', 'plugins', 'colors']
     install_subdir('data' / data_module , install_dir : lite_datadir)
 endforeach
 
-foreach file : ['usage.md', 'licenses.md', 'contributors.md', 'default-keymap.md']
-    install_data('doc' / file, install_dir : lite_docdir)
-endforeach
+install_data('licenses/licenses.md', install_dir : lite_docdir)
 
 lite_link_args = []
 if cc.get_id() == 'gcc' and get_option('buildtype') == 'release'


### PR DESCRIPTION
Previous commit (https://github.com/franko/lite-xl/commit/8c1a25100cbeabc29fa7c4e621d6fe0d30d998a8) changed the locations of certain documentation files causing the meson build to fail.