### PR TITLE
Commands refactor

### DIFF
--- a/data/core/commands/command.lua
+++ b/data/core/commands/command.lua
@@ -1,13 +1,7 @@
 local core = require "core"
 local command = require "core.command"
-local CommandView = require "core.commandview"
 
-local function has_commandview()
-  return core.active_view:is(CommandView)
-end
-
-
-command.add(has_commandview, {
+command.add("core.commandview", {
   ["command:submit"] = function()
     core.active_view:submit()
   end,

--- a/data/core/commands/dialog.lua
+++ b/data/core/commands/dialog.lua
@@ -1,0 +1,34 @@
+local core = require "core"
+local command = require "core.command"
+
+command.add("core.nagview", {
+  ["dialog:previous-entry"] = function()
+    local v = core.active_view
+    local hover = v.hovered_item or 1
+    v:change_hovered(hover == 1 and #v.options or hover - 1)
+  end,
+  ["dialog:next-entry"] = function()
+    local v = core.active_view
+    local hover = v.hovered_item or 1
+    v:change_hovered(hover == #v.options and 1 or hover + 1)
+  end,
+  ["dialog:select-yes"] = function()
+    local v = core.active_view
+    if v ~= core.nag_view then return end
+    v:change_hovered(findindex(v.options, "default_yes"))
+    command.perform "dialog:select"
+  end,
+  ["dialog:select-no"] = function()
+    local v = core.active_view
+    if v ~= core.nag_view then return end
+    v:change_hovered(findindex(v.options, "default_no"))
+    command.perform "dialog:select"
+  end,
+  ["dialog:select"] = function()
+    local v = core.active_view
+    if v.hovered_item then
+      v.on_selected(v.options[v.hovered_item])
+      v:next()
+    end
+  end
+})

--- a/data/core/nagview.lua
+++ b/data/core/nagview.lua
@@ -212,36 +212,4 @@ function NagView:show(title, message, options, on_select)
   if #self.queue > 0 and not self.title then self:next() end
 end
 
-command.add(NagView, {
-  ["dialog:previous-entry"] = function()
-    local v = core.active_view
-    local hover = v.hovered_item or 1
-    v:change_hovered(hover == 1 and #v.options or hover - 1)
-  end,
-  ["dialog:next-entry"] = function()
-    local v = core.active_view
-    local hover = v.hovered_item or 1
-    v:change_hovered(hover == #v.options and 1 or hover + 1)
-  end,
-  ["dialog:select-yes"] = function()
-    local v = core.active_view
-    if v ~= core.nag_view then return end
-    v:change_hovered(findindex(v.options, "default_yes"))
-    command.perform "dialog:select"
-  end,
-  ["dialog:select-no"] = function()
-    local v = core.active_view
-    if v ~= core.nag_view then return end
-    v:change_hovered(findindex(v.options, "default_no"))
-    command.perform "dialog:select"
-  end,
-  ["dialog:select"] = function()
-    local v = core.active_view
-    if v.hovered_item then
-      v.on_selected(v.options[v.hovered_item])
-      v:next()
-    end
-  end,
-})
-
 return NagView


### PR DESCRIPTION
This PR moves command registration in `NagView` to `core/commands/dialog.lua`. When the time is ripe, other Views that want to take advantage of `dialog:*` commands can do so.

I also removed a redundant check in the code.