### PR TITLE
fork process to give back console

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,7 @@
   #include <unistd.h>
   #include <signal.h>
 #elif __APPLE__
+  #include <unistd.h>
   #include <mach-o/dyld.h>
 #endif
 
@@ -84,6 +85,16 @@ void set_macos_bundle_resources(lua_State *L);
 #endif
 
 int main(int argc, char **argv) {
+#ifndef _WIN32
+  pid_t pid = fork();
+  if (pid)
+  {
+    // fork off the process so we can return control of the terminal to the user
+    // not applicable on Windows since applications using the GUI subsystem don't reserve the command prompt
+    return 0;
+  }
+#endif
+
 #ifdef _WIN32
   HINSTANCE lib = LoadLibrary("user32.dll");
   int (*SetProcessDPIAware)() = (void*) GetProcAddress(lib, "SetProcessDPIAware");


### PR DESCRIPTION
Fork off the process to give back control to the caller

Not Applicable on Windows since applications using the GUI subsystem do not reserve the command prompt for themselves

Before:
![image](https://user-images.githubusercontent.com/15076013/136906942-010e5ddb-6c90-4bbf-8557-6cbfe74a4391.png)

After:
![image](https://user-images.githubusercontent.com/15076013/136906738-13d9c95c-ec6e-4003-afb5-fd9caee4ffed.png)
