### PR TITLE
rely on /proc/self

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -32,8 +32,7 @@ static void get_exe_filename(char *buf, int sz) {
   int len = GetModuleFileName(NULL, buf, sz - 1);
   buf[len] = '\0';
 #elif __linux__
-  char path[512];
-  sprintf(path, "/proc/%d/exe", getpid());
+  char path[] = "/proc/self/exe";
   int len = readlink(path, buf, sz - 1);
   buf[len] = '\0';
 #elif __APPLE__


### PR DESCRIPTION
`/proc/getpid()` and `/proc/self` are the same so hardcoding it is easier