### PR TITLE
Improve python docstring highlighting

### DIFF
--- a/data/plugins/language_python.lua
+++ b/data/plugins/language_python.lua
@@ -7,7 +7,7 @@ syntax.add {
   comment = "#",
   patterns = {
     { pattern = { "#", "\n" },                  type = "comment"  },
-    { pattern = { '[ruU]?"""', '"""', '\\' },   type = "string"   },    
+    { pattern = { '[ruU]?"""', '"""', '\\' },   type = "string"   },
     { pattern = { '[ruU]?"', '"', '\\' },       type = "string"   },
     { pattern = { "[ruU]?'", "'", '\\' },       type = "string"   },
     { pattern = "0x[%da-fA-F]+",                type = "number"   },


### PR DESCRIPTION
Move the docstrings match up, so it captures properly.

Also allow raw & unicode docstrings, which were left out before.

Fixes #622