### PR TITLE
Updating the **Installing prebuild** section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,14 @@ cd lite-xl
 
 To run lite-xl without installing:
 ```sh
-cd bin
 ./lite-xl
 ```
 
 To install lite-xl copy files over into appropriate directories:
 
 ```sh
-mkdir -p $HOME/.local/bin && cp bin/lite-xl $HOME/.local/bin
-cp -r share $HOME/.local
+mkdir -p $HOME/.local/bin && cp lite-xl $HOME/.local/bin/
+mkdir -p $HOME/.local/share/lite-xl && cp -r data/* $HOME/.local/share/lite-xl/
 ```
 
 If `$HOME/.local/bin` is not in PATH:


### PR DESCRIPTION
Sub sections that I've updated:
*To run lite-xl without installing:*
*To install lite-xl copy files over into appropriate directories:*

I think the directory structure of prebuilt packages has changed since when README.md was last updated. 
I've just updated it. Just that.