### PR TITLE
feat(core): implement centralized logging with SDL

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -81,12 +81,12 @@ static int checkcontrol(lua_State *L, const char *msg, int tocont) {
   if (strcmp(msg, "off") == 0)
     lua_setwarnf(L, warnoff, L); // disable warning
   else if (strcmp(msg, "on") == 0)
-    lua_setwarnf(L, lxl_log_lua_warnf, L); // enable warning
+    lua_setwarnf(L, lxl_log_setwarnf, L); // enable warning
   return 1;
 }
 
 // warn handler when warning is turned on (default)
-void lxl_log_lua_warnf(void *ud, const char *msg, int tocont) {
+void lxl_log_setwarnf(void *ud, const char *msg, int tocont) {
   lua_State *L = (lua_State*) ud;
 
   if (checkcontrol(L, msg, tocont))

--- a/src/log.c
+++ b/src/log.c
@@ -1,0 +1,120 @@
+#include <stdarg.h>
+#include <SDL.h>
+#include <lua.h>
+#include <lauxlib.h>
+#include "log.h"
+
+#define LXL_LOG_STR_IDX "__lxl_log_str__"
+
+// TODO: thread safety
+static SDL_LogOutputFunction default_fn = NULL;
+static void *default_userdata = NULL;
+
+static void lxl_log(void *userdata, int category, SDL_LogPriority priority, const char *message) {
+  if (default_fn)
+    default_fn(default_userdata, category, priority, message);
+  if (priority == SDL_LOG_PRIORITY_CRITICAL)
+    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Critical error", message, NULL);
+}
+
+void lxl_log_init() {
+  SDL_LogOutputFunction fn;
+  void *data;
+  SDL_LogGetOutputFunction(&fn, &data);
+
+  if (default_fn != fn && fn != lxl_log) {
+    default_fn = fn;
+    default_userdata = data;
+  }
+
+  if (getenv("LITE_XL_DEBUG"))
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_VERBOSE);
+}
+
+void lxl_log_verbose(const char *fmt, ...) {
+  va_list ap;
+
+  va_start(ap, fmt);
+  SDL_LogMessageV(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_VERBOSE, fmt, ap);
+  va_end(ap);
+}
+
+void lxl_log_info(const char *fmt, ...) {
+  va_list ap;
+
+  va_start(ap, fmt);
+  SDL_LogMessageV(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO, fmt, ap);
+  va_end(ap);
+}
+
+void lxl_log_warn(const char *fmt, ...) {
+  va_list ap;
+
+  va_start(ap, fmt);
+  SDL_LogMessageV(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_WARN, fmt, ap);
+  va_end(ap);
+}
+
+void lxl_log_error(const char *fmt, ...) {
+  va_list ap;
+
+  va_start(ap, fmt);
+  SDL_LogMessageV(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_ERROR, fmt, ap);
+  va_end(ap);
+}
+
+void lxl_log_critical(const char *fmt, ...) {
+  va_list ap;
+
+  va_start(ap, fmt);
+  SDL_LogMessageV(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_CRITICAL, fmt, ap);
+  va_end(ap);
+}
+
+static void warnoff(void *ud, const char *msg, int tocont);
+
+static int checkcontrol(lua_State *L, const char *msg, int tocont) {
+  // adapted from Lua 5.4 source code
+  // https://www.lua.org/source/5.4/lauxlib.c.html#checkcontrol
+  if (tocont || *(msg++) != '@')
+    return 0;
+  if (strcmp(msg, "off") == 0)
+    lua_setwarnf(L, warnoff, L); // disable warning
+  else if (strcmp(msg, "on") == 0)
+    lua_setwarnf(L, lxl_log_lua_warnf, L); // enable warning
+  return 1;
+}
+
+// warn handler when warning is turned on (default)
+void lxl_log_lua_warnf(void *ud, const char *msg, int tocont) {
+  lua_State *L = (lua_State*) ud;
+
+  if (checkcontrol(L, msg, tocont))
+    return;
+
+  // get an existing warning
+  if (lua_getfield(L, LUA_REGISTRYINDEX, LXL_LOG_STR_IDX) != LUA_TSTRING) {
+    lua_pop(L, 1);
+    lua_pushliteral(L, "");
+  }
+  lua_pushnil(L);
+  lua_setfield(L, LUA_REGISTRYINDEX, LXL_LOG_STR_IDX);
+
+  // concatenate the last warn message with the current one
+  lua_pushstring(L, msg);
+  lua_concat(L, 2);
+
+  if (tocont) {
+    // if we have more message, save this warn message to the registry
+    lua_setfield(L, LUA_REGISTRYINDEX, LXL_LOG_STR_IDX);
+  } else {
+    // just print it
+    lxl_log_warn("%s", lua_tostring(L, -1));
+    lua_pop(L, 1);
+  }
+}
+
+// warn handler when warning is turned off
+static void warnoff(void *ud, const char *msg, int tocont) {
+  checkcontrol((lua_State*) ud, msg, tocont);
+}

--- a/src/log.h
+++ b/src/log.h
@@ -4,7 +4,7 @@
 void lxl_log_init();
 
 // call lua_setwarnf with this function and the lua_State as userdata
-void lxl_log_lua_warnf(void *ud, const char *msg, int tocont);
+void lxl_log_setwarnf(void *ud, const char *msg, int tocont);
 
 void lxl_log_verbose(const char *fmt, ...);
 void lxl_log_info(const char *fmt, ...);

--- a/src/log.h
+++ b/src/log.h
@@ -1,0 +1,15 @@
+#ifndef LOG_H
+#define LOG_H
+
+void lxl_log_init();
+
+// call lua_setwarnf with this function and the lua_State as userdata
+void lxl_log_lua_warnf(void *ud, const char *msg, int tocont);
+
+void lxl_log_verbose(const char *fmt, ...);
+void lxl_log_info(const char *fmt, ...);
+void lxl_log_warn(const char *fmt, ...);
+void lxl_log_error(const char *fmt, ...);
+void lxl_log_critical(const char *fmt, ...);
+
+#endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,6 +6,7 @@ lite_sources = [
     'api/system.c',
     'api/process.c',
     'api/utf8.c',
+    'log.c',
     'arena_allocator.c',
     'renderer.c',
     'renwindow.c',


### PR DESCRIPTION
Previously, logs go through stderr.
This is not ideal on other platforms such as Windows because we don't open stderr by default.
This commit uses SDL functions which can be redirected to the debugger. In the future, this also allows us to write to files.

For logs with `level == critical`, a message box is displayed. This is because critical errors usually ends with Lite XL crashing, so a message box is more appropriate.

When `LXL_ENABLE_DEBUG_LOGGING` is set, any logs with `level == debug` will be printed. If it is unset, any logs with `level >= info` is printed. I think that this should be controlled at runtime as well, with an environment variable (`LITE_XL_DEBUG_INFO=1`).

This PR also wires the log to include Lua warnings. While we don't use any Lua warnings, it may benefit plugins that uses external libraries which may use this feature. For LuaJIT and older Lua, it may be sufficient to just polyfill it.