### PR TITLE
Fixing C library loading (Attempt 2)

### DIFF
--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -37,11 +37,47 @@ package.cpath =
   DATADIR .. '/?/init.' .. suffix .. ";"
 
 package.native_plugins = {}
-package.searchers = { package.searchers[1], package.searchers[2], function(modname)
+
+local function sanitize_entrypoint(name)
+  return name:match("[^%-]*"):gsub("%.", "_")
+end
+
+local function load_function(modname, path)
+  local err_msg = {}
+  local entrypoint = sanitize_entrypoint(modname)
+  for prefix in ipairs { "luaopen_lite_xl_", "luaopen_" } do
+    local fn, err = system.loadlib(path, prefix .. entrypoint, prefix == "luaopen_lite_xl_")
+    if not fn then
+      err_msg[#err_msg+1] = string.format("%s:%s%s: %s", path, prefix, entrypoint, err)
+    else
+      return fn
+    end
+  end
+  return "no symbol '" .. table.concat(err_msg, "'\n\tno symbol '")
+end
+
+---The normal C library searcher, implemented with system.loadlib.
+local function clib_searcher(modname)
   local path, err = package.searchpath(modname, package.cpath)
-  if not path then return err end
-  return system.load_native_plugin, path
-end }
+  return (path and load_function(modname, path) or err), path
+end
+
+---The normal C root (all-in-one) searcher, implemented with system.loadlib.
+local function croot_searcher(modname)
+  local root = modname:match("^[^%.]*")
+  local path, err = package.searchpath(root, package.cpath)
+  return (path and load_function(modname, path) or err), path
+end
+
+---Lite XL's own C library searcher.
+---This searcher searches for the library file normally, but only uses the last part of the module to resolve symbols.
+local function lite_xl_searcher(modname)
+  local mod = modname:match("[^%.]*$")
+  local path, err = package.searchpath(modname, package.cpath)
+  return (path and load_function(mod, path) or err), path
+end
+
+package.searchers = { package.searchers[1], package.searchers[2], clib_searcher, croot_searcher, lite_xl_searcher }
 
 table.pack = table.pack or pack or function(...) return {...} end
 table.unpack = table.unpack or unpack

--- a/docs/api/system.lua
+++ b/docs/api/system.lua
@@ -334,6 +334,23 @@ function system.fuzzy_match(haystack, needle, file) end
 function system.set_window_opacity(window, opacity) end
 
 ---
+---Dynamically links Lite XL with a C library and optionally loads a function.
+---If funcname is "*", then no symbol loading will occur, and true is returned.
+---Note: This is a low level function and incorrect usage can cause crashes.
+---
+---@param libname string an absolute path to the C library.
+---@param funcname string the function name to load.
+---@param extended boolean? if true, the C function is assumed to have
+---lite-xL native plugin API's function signature instead of Lua C function signature.
+---
+---@return boolean|function|nil func the C function, or nil if an error occured.
+---@return string|nil error_msg a message describing the error.
+---@return "open"|"init"|nil error_type
+---"open" if an error occured when linking to the C library,
+---"init" if an error occured when attempting to load the symbol.
+function system.loadlib(libname, funcname, extended) end
+
+---
 ---Loads a lua native module using the default Lua API or lite-xl native plugin API.
 ---Note: Never use this function directly.
 ---

--- a/docs/api/system.lua
+++ b/docs/api/system.lua
@@ -354,6 +354,7 @@ function system.loadlib(libname, funcname, extended) end
 ---Loads a lua native module using the default Lua API or lite-xl native plugin API.
 ---Note: Never use this function directly.
 ---
+---@deprecated
 ---@param name string the name of the module
 ---@param path string the path to the shared library file
 ---@return number nargs the return value of the entrypoint

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -1118,7 +1118,7 @@ static void *load_library(lua_State *L, const char *path) {
   } else {
     lua_pop(L, 1);
     
-    if (lib = SDL_LoadObject(path)) {
+    if ((lib = SDL_LoadObject(path))) {
       *((void **) lua_newuserdata(L, sizeof(void *))) = lib;
       luaL_setmetatable(L, API_TYPE_NATIVE_PLUGIN);
       lua_setfield(L, -2, path);
@@ -1135,7 +1135,7 @@ static int extended_function_thunk(lua_State *L) {
   return fn(L, api_require);
 }
 
-static f_loadlib(lua_State *L) {
+static int f_loadlib(lua_State *L) {
   void *lib, *sym;
   const char *libname = luaL_checkstring(L, 1);
   const char *funcname = luaL_checkstring(L, 2);

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -1179,6 +1179,10 @@ static int f_load_native_plugin(lua_State *L) {
   char entrypoint_name[512]; entrypoint_name[sizeof(entrypoint_name) - 1] = '\0';
   int result;
 
+#if LUA_VERSION_NUM >= 503
+  lua_warning(L, "system.load_native_plugin is deprecated, and should not be used", 1);
+#endif
+
   const char *name = luaL_checkstring(L, 1);
   const char *path = luaL_checkstring(L, 2);
   void *library = load_library(L, path);
@@ -1358,6 +1362,7 @@ static const luaL_Reg lib[] = {
   { "fuzzy_match",           f_fuzzy_match           },
   { "set_window_opacity",    f_set_window_opacity    },
   { "loadlib",               f_loadlib               },
+  { "load_native_plugin",    f_load_native_plugin    }, // DEPRECATED!
   { "path_compare",          f_path_compare          },
   { "get_fs_type",           f_get_fs_type           },
   { "text_input",            f_text_input            },

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -1178,11 +1178,6 @@ static int f_loadlib(lua_State *L) {
 static int f_load_native_plugin(lua_State *L) {
   char entrypoint_name[512]; entrypoint_name[sizeof(entrypoint_name) - 1] = '\0';
   int result;
-
-#if LUA_VERSION_NUM >= 503
-  lua_warning(L, "system.load_native_plugin is deprecated, and should not be used", 1);
-#endif
-
   const char *name = luaL_checkstring(L, 1);
   const char *path = luaL_checkstring(L, 2);
   void *library = load_library(L, path);

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -1117,7 +1117,7 @@ static void *load_library(lua_State *L, const char *path) {
     lua_pop(L, 1);
   } else {
     lua_pop(L, 1);
-    
+
     if ((lib = SDL_LoadObject(path))) {
       *((void **) lua_newuserdata(L, sizeof(void *))) = lib;
       luaL_setmetatable(L, API_TYPE_NATIVE_PLUGIN);
@@ -1151,8 +1151,10 @@ static int f_loadlib(lua_State *L) {
   }
 
   if (strcmp(funcname, "*") == 0) {
-    lua_pushboolean(L, 1);
-    return 1;
+    lua_pushnil(L);
+    lua_pushliteral(L, "Loading library symbols with * is not supported");
+    lua_pushliteral(L, "init");
+    return 3;
   }
 
   sym = SDL_LoadFunction(lib, funcname);


### PR DESCRIPTION
Continued from #1433.

Previously there was an argument to whether we should adhere to Lua's convention for loading all-in-one modules (a C library that contains symbols for multiple submodules) or our own convention.

1. The all-in-one module takes the first part of module name as root; it resolves the library file based on the root, and loads the symbol based on entire module name.
2. We take the entire module name, and takes the last part of the module name to resolve the symbol. This can be more intuitive.

For instance, for the module `a.b.c`, Lua will load `a.so` and find `luaopen_a_b_c`, while we will load `a/b/c.so` and find `luaopen_c`. You can see why this is advantageous for us because shared libraries can now be put into the same directory as plugins and be loaded without some serious `package.cpath` modification.

The compromise is - we support both. C library and all-in-one searchers get to support lite-xl native plugin API, and the lite-xl way of resolving C library is implemented as another searcher (package.searchers[5]).