### PR TITLE
keymap multistroke support

### DIFF
--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -77,7 +77,7 @@ command.add(nil, {
         for i, name in ipairs(res) do
           res[i] = {
             text = command.prettify_name(name),
-            info = keymap.get_binding(name),
+            info = keymap.binding_to_string(keymap.get_binding(name)),
             command = name,
           }
         end

--- a/data/core/commands/findreplace.lua
+++ b/data/core/commands/findreplace.lua
@@ -19,9 +19,9 @@ local function doc()
 end
 
 local function get_find_tooltip()
-  local rf = keymap.get_binding("find-replace:repeat-find")
-  local ti = keymap.get_binding("find-replace:toggle-sensitivity")
-  local tr = keymap.get_binding("find-replace:toggle-regex")
+  local rf = keymap.binding_to_string(keymap.get_binding("find-replace:repeat-find"))
+  local ti = keymap.binding_to_string(keymap.get_binding("find-replace:toggle-sensitivity"))
+  local tr = keymap.binding_to_string(keymap.get_binding("find-replace:toggle-regex"))
   return (find_regex and "[Regex] " or "") ..
     (case_sensitive and "[Sensitive] " or "") ..
     (rf and ("Press " .. rf .. " to select the next match.") or "") ..

--- a/data/core/contextmenu.lua
+++ b/data/core/contextmenu.lua
@@ -65,7 +65,7 @@ local function update_items_size(items, update_binding)
   local width, height = 0, 0
   for _, item in ipairs(items) do
     if update_binding and item ~= DIVIDER then
-      item.info = keymap.get_binding(item.command)
+      item.info = keymap.binding_to_string(keymap.get_binding(item.command))
     end
     local lw, lh = get_item_size(item)
     width = math.max(width, lw)

--- a/data/core/emptyview.lua
+++ b/data/core/emptyview.lua
@@ -34,7 +34,7 @@ local function draw_text(x, y, color)
   y = y + (dh - (th + style.padding.y) * #lines) / 2
   local w = 0
   for _, line in ipairs(lines) do
-    local text = string.format(line.fmt, keymap.get_binding(line.cmd))
+    local text = string.format(line.fmt, keymap.binding_to_string(keymap.get_binding(line.cmd)))
     w = math.max(w, renderer.draw_text(style.font, text, x + style.padding.x, y, color))
     y = y + th + style.padding.y
   end

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -4,7 +4,7 @@ local config = require "core.config"
 local ime = require "core.ime"
 local keymap = {}
 
----@alias keymap.shortcut string
+---@alias keymap.shortcut string | string[]
 ---@alias keymap.command string
 ---@alias keymap.modkey string
 ---@alias keymap.pressed boolean
@@ -23,8 +23,8 @@ keymap.map = {}
 ---@type keymap.rmap
 keymap.reverse_map = {}
 
----Current multi-stroke state
----@type keymap.shortcut[]
+---Current multi-stroke state.
+---@type string[] | nil
 keymap.current_strokes = nil
 
 
@@ -40,11 +40,7 @@ local modkey_map = modkeys_os.map
 local modkeys = modkeys_os.keys
 
 
-local stroke_sep = " "
-local stroke_sep_pat = "[^" .. stroke_sep .. "]+"
-
-
----Normalizes a single stroke sequence to follow the modkeys table
+---Normalizes a single stroke sequence to follow the modkeys table.
 ---@param stroke string
 ---@return string
 local function normalize_stroke(stroke)
@@ -65,16 +61,16 @@ local function normalize_stroke(stroke)
 end
 
 
----Splits a stroke into a sequence of substrokes
----@param strokes string
----@return string stroke The normalized stroke
----@return string[] substrokes The normalized substrokes
-local function split_strokes(strokes)
-  local substrokes = {}
-  for substroke in strokes:gmatch(stroke_sep_pat) do
-    table.insert(substrokes, normalize_stroke(substroke))
+---Normalizes one or multiple strokes as per the modkey table.
+---@param strokes string | string[]
+---@return string[]
+local function normalize_strokes(strokes)
+  if type(strokes) == "string" then return { normalize_stroke(strokes) } end
+  local ret = {}
+  for _, stroke in ipairs(strokes) do
+    table.insert(ret, normalize_stroke(stroke))
   end
-  return table.concat(substrokes, stroke_sep), substrokes
+  return ret
 end
 
 
@@ -92,7 +88,7 @@ local function key_to_stroke(key)
 end
 
 
----Returns the value at `tbl[keys[1]]...[keys[#keys]]`
+---Returns the value at `tbl[keys[1]]...[keys[#keys]]`.
 ---@param tbl table<any, any> Base table
 ---@param keys any[] Keys
 ---@return any? # `tbl[keys[1]]...[keys[#keys]]`
@@ -106,7 +102,7 @@ local function get_nested(tbl, keys)
 end
 
 
----Sets the value of `tbl[keys[1]]...[keys[#keys]]` to v
+---Sets the value of `tbl[keys[1]]...[keys[#keys]]` to v.
 ---@param tbl table<any, any> Base table
 ---@param keys any[] Keys
 ---@param v any?
@@ -121,16 +117,35 @@ local function set_nested(tbl, keys, v)
 end
 
 
+---Checks two strokes for equality.
+---@param s1 keymap.shortcut
+---@param s2 keymap.shortcut
+---@return boolean
+local function stroke_equals(s1, s2)
+  if type(s1) ~= "table" then
+    return type(s2) ~= "table" and (s1 == s2) or (#s2 == 1 and s1 == s2[1])
+  end
+  local len = #s1
+  if len ~= #s2 then return false end
+  for i = 1, len do
+    if s1[i] ~= s2[i] then
+      return false
+    end
+  end
+  return true
+end
+
+
 ---Remove the given value from an array associated to a key in a table.
----@param tbl table<string, string> The table containing the key
+---@param tbl table<string, string  | string[]> The table containing the key
 ---@param k string The key containing the array
----@param v? string The value to remove from the array
+---@param v? string | string[] The value to remove from the array
 local function remove_only(tbl, k, v)
   if tbl[k] then
     if v then
       local j = 0
       for i=1, #tbl[k] do
-        while tbl[k][i + j] == v do
+        while stroke_equals(tbl[k][i + j], v) do
           j = j + 1
         end
         tbl[k][i] = tbl[k][i + j]
@@ -146,11 +161,11 @@ end
 ---@param map keymap.map
 local function remove_duplicates(map)
   for stroke, commands in pairs(map) do
-    local normalized_stroke, substrokes = split_strokes(stroke)
+    local strokes = normalize_strokes(stroke)
     if type(commands) == "string" or type(commands) == "function" then
       commands = { commands }
     end
-    local registered_cmds = get_nested(keymap.map, substrokes)
+    local registered_cmds = get_nested(keymap.map, strokes)
     if registered_cmds then
       for _, registered_cmd in ipairs(registered_cmds) do
         local j = 0
@@ -175,24 +190,24 @@ end
 ---@param map keymap.map
 function keymap.add_direct(map)
   for stroke, commands in pairs(map) do
-    local stroke, substrokes = split_strokes(stroke)
+    local strokes = normalize_strokes(stroke)
     if type(commands) == "string" or type(commands) == "function" then
       commands = { commands }
     end
-    local cmds = get_nested(keymap.map, substrokes)
+    local cmds = get_nested(keymap.map, strokes)
     if cmds then
       for s, cmd in pairs(cmds) do
         if type(s) == "number" then
-          remove_only(keymap.reverse_map, cmd, stroke)
+          remove_only(keymap.reverse_map, cmd, strokes)
         else
           commands[s] = cmd
         end
       end
     end
-    set_nested(keymap.map, substrokes, commands)
+    set_nested(keymap.map, strokes, commands)
     for _, cmd in ipairs(commands) do
       keymap.reverse_map[cmd] = keymap.reverse_map[cmd] or {}
-      table.insert(keymap.reverse_map[cmd], stroke)
+      table.insert(keymap.reverse_map[cmd], strokes)
     end
   end
 end
@@ -205,45 +220,58 @@ end
 function keymap.add(map, overwrite)
   remove_duplicates(map)
   for stroke, commands in pairs(map) do
+    local strokes = normalize_strokes(stroke)
     if macos then
-      stroke = stroke:gsub("%f[%a]ctrl%f[%A]", "cmd")
+      for i, s in ipairs(strokes) do
+        strokes[i] = s:gsub("%f[%a]ctrl%f[%A]", "cmd")
+      end
     end
-    local stroke, substrokes = split_strokes(stroke)
     if overwrite then
-      local cmds = get_nested(keymap.map, substrokes)
+      local cmds = get_nested(keymap.map, strokes)
       if cmds then
         for s, cmd in pairs(cmds) do
           if type(s) == "number" then
-            remove_only(keymap.reverse_map, cmd, stroke)
+            remove_only(keymap.reverse_map, cmd, strokes)
           else
             commands[s] = cmd
           end
         end
       end
-      set_nested(keymap.map, substrokes, commands)
+      set_nested(keymap.map, strokes, commands)
     else
-      local cmds = get_nested(keymap.map, substrokes) or { }
+      local cmds = get_nested(keymap.map, strokes) or { }
       for i = #commands, 1, -1 do
         table.insert(cmds, 1, commands[i])
       end
-      set_nested(keymap.map, substrokes, cmds)
+      set_nested(keymap.map, strokes, cmds)
     end
     for _, cmd in ipairs(commands) do
       keymap.reverse_map[cmd] = keymap.reverse_map[cmd] or {}
-      table.insert(keymap.reverse_map[cmd], stroke)
+      table.insert(keymap.reverse_map[cmd], strokes)
     end
   end
 end
 
 
 ---Unregisters the given shortcut and associated command.
----@param shortcut string
+---@param shortcut string | string[]
 ---@param cmd string
 function keymap.unbind(shortcut, cmd)
-  local shortcut, substrokes = split_strokes(shortcut)
-  local last_sub = table.remove(substrokes)
-  remove_only(get_nested(keymap.map, substrokes) or { }, last_sub, cmd)
-  remove_only(keymap.reverse_map, cmd, shortcut)
+  local strokes = normalize_strokes(shortcut)
+  remove_only(keymap.reverse_map, cmd, strokes)
+  local last_sub = table.remove(strokes)
+  remove_only(get_nested(keymap.map, strokes) or { }, last_sub, cmd)
+  table.insert(strokes, last_sub)
+  -- remove empty submaps to avoid entering multi stroke state if all commands
+  -- prefixed with shortcut or a subsequence have been removed
+  while #strokes > 0 do
+    local submap = get_nested(keymap.map, strokes)
+    if next(submap) then
+      break
+    end
+    set_nested(keymap.map, strokes, nil)
+    table.remove(strokes)
+  end
 end
 
 
@@ -257,9 +285,17 @@ end
 
 ---Returns all the shortcuts associated to a command packed in a table.
 ---@param cmd string
----@return table<integer, string> | nil shortcuts
+---@return keymap.shortcut[] | nil shortcuts
 function keymap.get_bindings(cmd)
   return keymap.reverse_map[cmd]
+end
+
+---Returns a string representation of a shortcut.
+---@param shortcut? keymap.shortcut
+---@return string
+function keymap.binding_to_string(shortcut)
+  if not shortcut then return "" end
+  return type(shortcut) ~= "table" and shortcut or table.concat(shortcut, " ")
 end
 
 
@@ -276,7 +312,7 @@ function keymap.on_key_pressed(k, ...)
     end
   else
     local stroke = key_to_stroke(k)
-    keymap.current_strokes = keymap.current_strokes or { }
+    keymap.current_strokes = keymap.current_strokes or {}
     table.insert(keymap.current_strokes, stroke)
     local commands, performed = get_nested(keymap.map, keymap.current_strokes), false
     if commands then

--- a/data/core/statusview.lua
+++ b/data/core/statusview.lua
@@ -274,7 +274,7 @@ function StatusView:register_docview_items()
     name = "keymap:current-stroke",
     alignment = StatusView.Item.LEFT,
     get_item = function()
-      return { style.text, table.concat(keymap.current_strokes, " ") }
+      return { style.text, keymap.binding_to_string(keymap.current_strokes) }
     end
   })
 


### PR DESCRIPTION
This pr adds basic support for multi stroke shortcuts.

    local keymap = require 'core.keymap`
    keymap.add { ['ctrl+b p'] = 'core:find-command' }

A few things are still tbd:

- the general behavior is to accept shortcuts which are a strict prefix of others  (e.g `a b` -> `a b c`) and prioritizes them over longer strokes; i.e multi-stroke state is only entered if no suitable command was found
- the current stroke separator is a space (` `), which obviously doesn't play nice with the keypad keys
- I am unsure of the handling of replacing (`add_direct`, `add(_, true)`) with a longer stroke. Should every other shortcut with a common prefix be removed or only those whose last substroke does not match? (for now, it leaves all shorter strokes)
- on the other hand, replacing straight up removes all longer strokes. should it be only the ones with the exact same stroke?
- `keymap:cancel-stroke` should probably be a thing. should it go in `commands/core.lua`?