### PR TITLE
renderer: add support for drawing polygons

### DIFF
--- a/docs/api/renderer.lua
+++ b/docs/api/renderer.lua
@@ -15,6 +15,23 @@ renderer = {}
 ---@field public b number Blue
 ---@field public a number Alpha
 
+---Represent a point in a poly line, in the form of { x, y }.
+---@alias renderer.normal_point integer[]
+
+---Represent a conic / quadratic bezier curve with a single control point,
+---in the form of { start_x, start_y, cp1_x, cp1_y, end_x, end_y }.
+---@alias renderer.conic_bezier integer[]
+
+---Represent a cubic bezier curve with two control points,
+---in the form of { start_x, start_y, cp1_x, cp1_y, cp2_x, cp2_y, end_x, end_y }.
+---@alias renderer.cubic_bezier integer[]
+
+---Represent all types accepted by the renderer.draw_poly function.
+---@alias renderer.poly_object
+---|renderer.normal_point
+---|renderer.conic_bezier
+---|renderer.cubic_bezier
+
 ---
 ---Represent options that affect a font's rendering.
 ---@class renderer.fontoptions
@@ -155,6 +172,24 @@ function renderer.draw_rect(x, y, width, height, color) end
 ---
 ---@return number x
 function renderer.draw_text(font, text, x, y, color) end
+
+
+---
+---Draws a filled polygon, consisting of curves and points.
+---The polygon is filled using the non-zero winding rule in clockwise direction.
+---
+---The function returns the control box of the polygon,
+---which is greater than or equal to the dimensions of the rendered polygon.
+---It is not guaranteed to the exact dimension of the rendered polygon.
+---
+---@param poly renderer.poly_object[] the lines or curves to draw, up to 65535 points.
+---@param color renderer.color
+---
+---@return number x the X coordinate of top left corner of the control box.
+---@return number y the Y coordinate of the top left corner of the control box.
+---@return number w the width of the control box.
+---@return number h the height of the control box.
+function renderer.draw_poly(poly, color) end
 
 
 return renderer

--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -352,6 +352,57 @@ static int f_draw_rect(lua_State *L) {
   return 0;
 }
 
+static void *realloc_ud(lua_State *L, int ref, void *prev, size_t s) {
+  void *ptr = lua_newuserdatauv(L, s, 1);
+  lua_pushinteger(L, s); lua_setiuservalue(L, -2, 1);
+  lua_rawsetp(L, ref, ptr);
+  if (prev) {
+    if (lua_rawgetp(L, ref, prev) != LUA_TUSERDATA) luaL_error(L, "invalid previous pointer");
+    lua_getiuservalue(L, -1, 1); memcpy(ptr, prev, lua_tointeger(L, -1)); // copy previous memory
+    lua_pushnil(L); lua_rawsetp(L, ref, prev); // remove previous allocated memory
+    lua_pop(L, 2);
+  }
+  return ptr;
+}
+
+static int f_draw_poly(lua_State *L) {
+  static const char normal_tag[] = { POLY_NORMAL };
+  static const char conic_bezier_tag[] = { POLY_NORMAL, POLY_CONTROL_CONIC, POLY_NORMAL };
+  static const char cubic_bezier_tag[] = { POLY_NORMAL, POLY_CONTROL_CUBIC, POLY_CONTROL_CUBIC, POLY_NORMAL };
+
+  assert(active_window_renderer != NULL);
+  luaL_checktype(L, 1, LUA_TTABLE);
+  RenColor color = checkcolor(L, 2, 255);
+  lua_settop(L, 2);
+  // create a table, and store all the renpoint as userdata in the table as crude GC
+  int arena_idx = (lua_newtable(L), lua_gettop(L));
+
+  int len = luaL_len(L, 1);
+  RenPoint *points = NULL; int npoints = 0;
+  for (int i = 1; i <= len; i++) {
+    lua_rawgeti(L, 1, i); luaL_checktype(L, -1, LUA_TTABLE);
+    const char *current_tag = NULL; int coord_len = luaL_len(L, -1);
+    switch (coord_len) {
+      case 2: current_tag = normal_tag;       break; // 1 curve point
+      case 6: current_tag = conic_bezier_tag; break; // a conic bezier with 2 curve points and 1 control point
+      case 8: current_tag = cubic_bezier_tag; break; // a cubic bezier with 2 curve points and 2 control points
+      default: return luaL_error(L, "invalid number of points, expected 2, 6 and 8, got %d", coord_len);
+    }
+    if (npoints + coord_len / 2 > MAX_POLY_POINTS) return luaL_error(L, "too many points");
+    points = realloc_ud(L, arena_idx, points, (npoints + coord_len / 2) * sizeof(RenPoint));
+    for (int lidx = 1; lidx <= coord_len; lidx += 2) {
+      points[npoints].x = (lua_rawgeti(L, -1, lidx),   luaL_checknumber(L, -1));
+      points[npoints].y = (lua_rawgeti(L, -2, lidx+1), luaL_checknumber(L, -1));
+      points[npoints++].tag = current_tag[(lidx-1)/2];
+      lua_pop(L, 2);
+    }
+  }
+  RenRect res = rencache_draw_poly(active_window_renderer, points, npoints, color);
+  lua_pushinteger(L, res.x);     lua_pushinteger(L, res.y);
+  lua_pushinteger(L, res.width); lua_pushinteger(L, res.height);
+  return 4;
+}
+
 static int f_draw_text(lua_State *L) {
   assert(active_window_renderer != NULL);
   RenFont* fonts[FONT_FALLBACK_MAX];
@@ -387,7 +438,8 @@ static const luaL_Reg lib[] = {
   { "set_clip_rect",      f_set_clip_rect      },
   { "draw_rect",          f_draw_rect          },
   { "draw_text",          f_draw_text          },
-  { NULL,                 NULL                 }
+  { "draw_poly",          f_draw_poly          },
+  { NULL,                 NULL                 },
 };
 
 static const luaL_Reg fontLib[] = {

--- a/src/rencache.c
+++ b/src/rencache.c
@@ -31,7 +31,7 @@
 #define CMD_BUF_INIT_SIZE (1024 * 512)
 #define COMMAND_BARE_SIZE offsetof(Command, command)
 
-enum CommandType { SET_CLIP, DRAW_TEXT, DRAW_RECT };
+enum CommandType { SET_CLIP, DRAW_TEXT, DRAW_RECT, DRAW_POLY };
 
 typedef struct {
   enum CommandType type;
@@ -59,6 +59,13 @@ typedef struct {
   RenRect rect;
   RenColor color;
 } DrawRectCommand;
+
+typedef struct {
+  RenRect rect;
+  RenColor color;
+  unsigned short npoints;
+  RenPoint points[];
+} DrawBezierCommand;
 
 static unsigned cells_buf1[CELLS_X * CELLS_Y];
 static unsigned cells_buf2[CELLS_X * CELLS_Y];
@@ -210,6 +217,23 @@ double rencache_draw_text(RenWindow *window_renderer, RenFont **fonts, const cha
   return x + width;
 }
 
+RenRect rencache_draw_poly(RenWindow *window_renderer, RenPoint *points, int npoints, RenColor color) {
+  RenRect rect;
+  if (ren_poly_cbox(points, npoints, &rect) != 0) {
+    return (RenRect){-1};
+  }
+  if (rects_overlap(last_clip_rect, rect)) {
+    size_t size = npoints + npoints * sizeof(RenPoint);
+    DrawBezierCommand *cmd = push_command(window_renderer, DRAW_POLY, sizeof(DrawBezierCommand) + size);
+    if (cmd) {
+      cmd->rect = rect;
+      cmd->color = color;
+      cmd->npoints = npoints;
+      memcpy(cmd->points, points, npoints * sizeof(RenPoint));
+    }
+  }
+  return rect;
+}
 
 void rencache_invalidate(void) {
   memset(cells_prev, 0xff, sizeof(cells_buf1));
@@ -310,6 +334,7 @@ void rencache_end_frame(RenWindow *window_renderer) {
       SetClipCommand *ccmd = (SetClipCommand*)&cmd->command;
       DrawRectCommand *rcmd = (DrawRectCommand*)&cmd->command;
       DrawTextCommand *tcmd = (DrawTextCommand*)&cmd->command;
+      DrawBezierCommand *bcmd = (DrawBezierCommand*)&cmd->command;
       switch (cmd->type) {
         case SET_CLIP:
           ren_set_clip_rect(window_renderer, intersect_rects(ccmd->rect, r));
@@ -320,6 +345,9 @@ void rencache_end_frame(RenWindow *window_renderer) {
         case DRAW_TEXT:
           ren_font_group_set_tab_size(tcmd->fonts, tcmd->tab_size);
           ren_draw_text(&rs, tcmd->fonts, tcmd->text, tcmd->len, tcmd->text_x, tcmd->rect.y, tcmd->color);
+          break;
+        case DRAW_POLY:
+          ren_draw_poly(&rs, bcmd->points, bcmd->npoints, bcmd->color);
           break;
       }
     }

--- a/src/rencache.h
+++ b/src/rencache.h
@@ -9,6 +9,7 @@ void  rencache_show_debug(bool enable);
 void  rencache_set_clip_rect(RenWindow *window_renderer, RenRect rect);
 void  rencache_draw_rect(RenWindow *window_renderer, RenRect rect, RenColor color);
 double rencache_draw_text(RenWindow *window_renderer, RenFont **font, const char *text, size_t len, double x, int y, RenColor color);
+RenRect rencache_draw_poly(RenWindow *window_renderer, RenPoint *points, int npoints, RenColor color);
 void  rencache_invalidate(void);
 void  rencache_begin_frame(RenWindow *window_renderer);
 void  rencache_end_frame(RenWindow *window_renderer);

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -31,6 +31,13 @@ static void* _check_alloc(void *ptr, const char *const file, size_t ln) {
   return ptr;
 }
 
+// the parameters passed into freetype's scanline converter
+typedef struct {
+  SDL_Surface *surface;
+  SDL_Rect clip;
+  RenColor color;
+} RenPolyParams;
+
 /************************* Fonts *************************/
 
 // approximate number of glyphs per atlas surface
@@ -204,7 +211,7 @@ static SDL_Surface *font_allocate_glyph_surface(RenFont *font, FT_GlyphSlot slot
     }
   }
   if (atlas_idx < 0) {
-    // create a new atlas with the correct width, for each subpixel bitmap  
+    // create a new atlas with the correct width, for each subpixel bitmap
     for (int i = 0; i < FONT_BITMAP_COUNT(font); i++) {
       font->glyphs.atlas[i] = check_alloc(realloc(font->glyphs.atlas[i], sizeof(GlyphAtlas) * (font->glyphs.natlas + 1)));
       font->glyphs.atlas[i][font->glyphs.natlas] = (GlyphAtlas) {
@@ -286,7 +293,7 @@ static void font_load_glyph(RenFont *font, unsigned int glyph_id) {
           && slot->bitmap.pixel_mode != FT_PIXEL_MODE_GRAY
           && slot->bitmap.pixel_mode != FT_PIXEL_MODE_LCD))
       continue;
-    
+
     unsigned int glyph_width = slot->bitmap.width / bitmaps;
     // FT_PIXEL_MODE_MONO uses 1 bit per pixel packed bitmap
     if (slot->bitmap.pixel_mode == FT_PIXEL_MODE_MONO) glyph_width *= 8;
@@ -302,7 +309,7 @@ static void font_load_glyph(RenFont *font, unsigned int glyph_id) {
     uint8_t* pixels = surface->pixels;
     for (unsigned int line = 0; line < slot->bitmap.rows; ++line) {
       int target_offset = surface->pitch * (line + metric->y0); // x0 is always assumed to be 0
-      int source_offset = line * slot->bitmap.pitch;  
+      int source_offset = line * slot->bitmap.pitch;
       if (font->antialiasing == FONT_ANTIALIASING_NONE) {
         for (unsigned int column = 0; column < slot->bitmap.width; ++column) {
           int current_source_offset = source_offset + (column / 8);
@@ -408,7 +415,7 @@ static int font_set_face_metrics(RenFont *font, FT_Face face) {
   } else {
     font->height = (short) font->face->size->metrics.height / 64.0f;
     font->baseline = (short) font->face->size->metrics.ascender / 64.0f;
-  }   
+  }
   if(!font->underline_thickness)
     font->underline_thickness = ceil((double) font->height / 14.0);
 
@@ -424,7 +431,7 @@ RenFont* ren_font_load(const char* path, float size, ERenFontAntialiasing antial
 
   file = SDL_RWFromFile(path, "rb");
   if (!file) return NULL;
-  
+
   int len = strlen(path);
   font = check_alloc(calloc(1, sizeof(RenFont) + len + 1));
   strcpy(font->path, path);
@@ -650,6 +657,65 @@ double ren_draw_text(RenSurface *rs, RenFont **fonts, const char *text, size_t l
   return pen_x / surface_scale;
 }
 
+#define ENSURE_RECT_SURFACE(s) \
+  if (!draw_rect_surface) \
+    draw_rect_surface = check_alloc(SDL_CreateRGBSurfaceWithFormat(0, 1, 1, (s)->format->BitsPerPixel, (s)->format->format))
+
+int ren_poly_cbox(RenPoint *points, int npoints, RenRect *cbox) {
+  if (npoints > MAX_POLY_POINTS) return -1;
+  if (npoints == 0) { memset(cbox, 0, sizeof(RenRect)); return 0; }
+  // the control box is just the min and max of all points,
+  // because the highest point of a curve can't go higher than the control point
+  RenPoint *end = points + npoints;
+  int xmin, ymin, xmax, ymax;
+  xmin = xmax = points->x; ymin = ymax = points->y;
+  points++;
+  for (; points < end; points++) {
+    if (points->x < xmin) xmin = points->x;
+    if (points->x > xmax) xmax = points->x;
+    if (points->y < ymin) ymin = points->y;
+    if (points->y > ymax) ymax = points->y;
+  }
+  cbox->x = xmin; cbox->y = ymin;
+  cbox->width = xmax - xmin; cbox->height = ymax - ymin;
+  return 0;
+}
+
+void raster_span(int y, int count, const FT_Span *spans, void *user) {
+  RenPolyParams *param = (RenPolyParams *) user;
+  if (y < param->clip.y || y >= param->clip.y + param->clip.h) return;
+  for (int i = 0; i < count; i++) {
+    SDL_Rect actual, span = { .x = spans[i].x, .y = y, .w = spans[i].len, .h = 1 };
+    if (span.x > param->clip.x + param->clip.w) break;
+    if (!SDL_IntersectRect(&param->clip, &span, &actual)) continue;
+    *((uint32_t *) draw_rect_surface->pixels) = SDL_MapRGBA(draw_rect_surface->format, param->color.r, param->color.g, param->color.b, (param->color.a * spans[i].coverage) >> 8);
+    SDL_BlitScaled(draw_rect_surface, NULL, param->surface, &actual);
+  }
+}
+
+void ren_draw_poly(RenSurface *rs, RenPoint *points, unsigned short npoints, RenColor color) {
+  FT_Outline outline;
+  if (npoints == 0 || npoints > MAX_POLY_POINTS) return;
+  if (FT_Outline_New(library, npoints, 1, &outline) != 0) return;
+  for (int i = 0; i < npoints; i++) {
+    // this is undocumented, but freetype seems to expect 26.6 fixed point numbers
+    outline.points[i].x = points[i].x * rs->scale * 64;
+    outline.points[i].y = points[i].y * rs->scale * 64;
+    outline.tags[i] = points[i].tag;
+  }
+  outline.contours[0] = npoints - 1;
+  ENSURE_RECT_SURFACE(rs->surface);
+  RenPolyParams params = { .color = color, .surface = rs->surface };
+  SDL_GetClipRect(rs->surface, &params.clip);
+  FT_Outline_Render(library, &outline, &(FT_Raster_Params) {
+    .target = NULL,
+    .flags = FT_RASTER_FLAG_AA | FT_RASTER_FLAG_DIRECT,
+    .gray_spans = &raster_span,
+    .user = &params,
+  });
+  FT_Outline_Done(library, &outline);
+}
+
 /******************* Rectangles **********************/
 static inline RenColor blend_pixel(RenColor dst, RenColor src) {
   int ia = 0xff - src.a;
@@ -679,7 +745,7 @@ void ren_draw_rect(RenSurface *rs, RenRect rect, RenColor color) {
     SDL_Rect clip;
     SDL_GetClipRect(surface, &clip);
     if (!SDL_IntersectRect(&clip, &dest_rect, &dest_rect)) return;
-
+    ENSURE_RECT_SURFACE(surface);
     uint32_t *pixel = (uint32_t *)draw_rect_surface->pixels;
     *pixel = SDL_MapRGBA(draw_rect_surface->format, color.r, color.g, color.b, color.a);
     SDL_BlitScaled(draw_rect_surface, NULL, surface, &dest_rect);
@@ -716,8 +782,8 @@ int ren_init(void) {
 }
 
 void ren_free(void) {
-  SDL_FreeSurface(draw_rect_surface);
-  FT_Done_FreeType(library);    
+  if (draw_rect_surface) SDL_FreeSurface(draw_rect_surface);
+  FT_Done_FreeType(library);
 }
 
 RenWindow* ren_create(SDL_Window *win) {

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -13,11 +13,14 @@
 
 
 #define FONT_FALLBACK_MAX 10
+#define MAX_POLY_POINTS 0xFFFF
 typedef struct RenFont RenFont;
 typedef enum { FONT_HINTING_NONE, FONT_HINTING_SLIGHT, FONT_HINTING_FULL } ERenFontHinting;
 typedef enum { FONT_ANTIALIASING_NONE, FONT_ANTIALIASING_GRAYSCALE, FONT_ANTIALIASING_SUBPIXEL } ERenFontAntialiasing;
 typedef enum { FONT_STYLE_BOLD = 1, FONT_STYLE_ITALIC = 2, FONT_STYLE_UNDERLINE = 4, FONT_STYLE_SMOOTH = 8, FONT_STYLE_STRIKETHROUGH = 16 } ERenFontStyle;
+typedef enum { POLY_CONTROL_CONIC = 0, POLY_CONTROL_CUBIC = 0b10, POLY_NORMAL = 0b01 } ERenBezierPointType;
 typedef struct { uint8_t b, g, r, a; } RenColor;
+typedef struct { int x, y; ERenBezierPointType tag; } RenPoint;
 typedef struct { int x, y, width, height; } RenRect;
 typedef struct { SDL_Surface *surface; int scale; } RenSurface;
 
@@ -40,6 +43,10 @@ double ren_font_group_get_width(RenFont **font, const char *text, size_t len, in
 double ren_draw_text(RenSurface *rs, RenFont **font, const char *text, size_t len, float x, int y, RenColor color);
 
 void ren_draw_rect(RenSurface *rs, RenRect rect, RenColor color);
+
+// function to draw polygons and curves
+int ren_poly_cbox(RenPoint *points, int npoints, RenRect *cbox);
+void ren_draw_poly(RenSurface *rs, RenPoint *points, unsigned short npoints, RenColor color);
 
 int ren_init(void);
 void ren_free(void);


### PR DESCRIPTION
Another idea I previously thought was impossible until I tried it. I've always theorized that we could borrow FreeType's outline processing abilities to draw polygons, and this PR uses FreeType outline processing functions with the direct scan-out mode to draw complex(er) shapes. This allows us to expose a very minimal interface to draw them with `renderer.draw_poly`.