### PR TITLE
default anti-aliasing to grayscale on non MacOS platforms

### DIFF
--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -83,12 +83,18 @@ static int font_get_options(
   return 0;
 }
 
+#ifdef SDL_PLATFORM_APPLE
+#define DEFAULT_ALIASING FONT_ANTIALIASING_SUBPIXEL
+#else
+#define DEFAULT_ALIASING FONT_ANTIALIASING_GRAYSCALE
+#endif
+
 static int f_font_load(lua_State *L) {
   const char *filename  = luaL_checkstring(L, 1);
   float size = luaL_checknumber(L, 2);
   int style = 0;
   ERenFontHinting hinting = FONT_HINTING_SLIGHT;
-  ERenFontAntialiasing antialiasing = FONT_ANTIALIASING_SUBPIXEL;
+  ERenFontAntialiasing antialiasing = DEFAULT_ALIASING;
 
   int ret_code = font_get_options(L, &antialiasing, &hinting, &style);
   if (ret_code > 0)


### PR DESCRIPTION
We default to subpixel rendering on all platforms however there are many monitors (especially in the higher price range) with more unique subpixel layouts that are not compatible with the expected RGB layout.

There is currently no efficient way to figure out what layout a given monitor uses programatically.
Some monitors expose this info over DDC however its unreliable and not always provided.
The best we could do is offer a configuration option to people, but even then it would be difficult for a user to know what the right option is without some sort of guide like this
![image](https://github.com/user-attachments/assets/f88fe2d8-f384-430d-b701-7cb4bd0b4f6f)

I've special cased the Apple platform here because newer MacOS systems come with High-DPI displays that are not affected by anti-aliasing but before that RGB is the expected subpixel layout.
This would still cause issues when an external display is connected but I think that is a less likely outcome.

