### PR TITLE
Consistently enforce stringification of text in fuzzy matching.

### DIFF
--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -153,7 +153,7 @@ end
 
 local function compare_score(a, b)
   if a.score == b.score then
-    return a.text < b.text
+    return tostring(a.text) < tostring(b.text)
   end
   return a.score > b.score
 end


### PR DESCRIPTION
Requires a tostring, as autocomplete passes an object with a metatable that overrides __tostring; and relies on this to work with fuzzy match. We already do this on L165, we just don't consistently do it in `compare_score`.