### PR TITLE
restore light lcd filter for slight hinting

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -171,7 +171,7 @@ static int font_set_render_options(RenFont* font) {
     unsigned char weights[] = { 0x10, 0x40, 0x70, 0x40, 0x10 } ;
     switch (font->hinting) {
       case FONT_HINTING_NONE: FT_Library_SetLcdFilter(library, FT_LCD_FILTER_NONE); break;
-      case FONT_HINTING_SLIGHT:
+      case FONT_HINTING_SLIGHT: FT_Library_SetLcdFilter(library, FT_LCD_FILTER_LIGHT); break;
       case FONT_HINTING_FULL: FT_Library_SetLcdFilterWeights(library, weights); break;
     }
     return FT_RENDER_MODE_LCD;


### PR DESCRIPTION
Slight hinting was made to use the same weights as full hinting in the worst cases this can result in extra blurring of the given font.

The current light weights in Freetype are:

```c
static const FT_LcdFiveTapFilter  light_weights = { 0x00, 0x55, 0x56, 0x55, 0x00 };
```

the full weights are based on what was used with the original font renderer
https://github.com/lite-xl/lite-xl/blob/f1a4bf82187836e93f7a650cf01e696dff7d45da/lib/font_renderer/font_renderer.cpp#L24
which got it from Franko's elementary-plotlib https://github.com/franko/elementary-plotlib/blob/50f110b56f27bb9f8bc1f47a16e8beae20c73d0b/src/render_config.cpp#L19

the original code applied the filter independent of the hinting and had no stages of hinting, only on or off, so the current code that we have isn't even accurate to the original logic.

This brings up the topic of default hinting, currently we use FONT_HINTING_SLIGHT where as the old code defaulted to none.

I've checked with the previous default values and the explicit weights are closer to the lcd full weights than the light weights, so at least that part seems correct.
