### PR TITLE
Update custom_events.c

### DIFF
--- a/src/custom_events.c
+++ b/src/custom_events.c
@@ -139,7 +139,7 @@ bool push_custom_event(const char *name, CustomEvent *event) {
 CustomEventCallback get_custom_event_callback_by_name(const char *name) {
   if (name == NULL || name[0] == '\0' || name[0] == TYPENAME_MARKER) {
     SDL_SetError("Invalid event name");
-    return false;
+    return NULL;
   }
 
   CustomEventData *ce = SDL_GetPointerProperty(custom_events_property, name, NULL);


### PR DESCRIPTION
the documentation says:
```
Returns the registered callback of the given name.

Returns NULL only if the event doesn't exist.
If the event didn't have a callback, a noop callback will be returned.
```
Hence I changed `false` to `NULL`