### PR TITLE
Permit fractional scroll wheel values

### DIFF
--- a/src/api/system.c
+++ b/src/api/system.c
@@ -325,9 +325,9 @@ top:
 
     case SDL_EVENT_MOUSE_WHEEL:
       lua_pushstring(L, "mousewheel");
-      lua_pushinteger(L, e.wheel.y);
+      lua_pushnumber(L, e.wheel.y);
       // Use -x to keep consistency with vertical scrolling values (e.g. shift+scroll)
-      lua_pushinteger(L, -e.wheel.x);
+      lua_pushnumber(L, -e.wheel.x);
       return 3;
 
     case SDL_EVENT_FINGER_DOWN:


### PR DESCRIPTION
I had this issue on Elementary OS where the editor wouldn't scroll with touchpad unless the swipes were big enough. Changing the API to return numbers instead of integers fixes it.