### PR TITLE
fix(doc): don't modify `doc` with empty clipboard paste

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -254,6 +254,9 @@ local commands = {
 
   ["doc:paste"] = function(dv)
     local clipboard = system.get_clipboard()
+    if not clipboard or clipboard == "" then
+    	return
+    end
     -- If the clipboard has changed since our last look, use that instead
     if core.cursor_clipboard["full"] ~= clipboard then
       core.cursor_clipboard = {}

--- a/docs/api/system.lua
+++ b/docs/api/system.lua
@@ -296,7 +296,7 @@ function system.get_fs_type(path) end
 ---
 ---Retrieve the text currently stored on the clipboard.
 ---
----@return string
+---@return string?
 function system.get_clipboard() end
 
 ---


### PR DESCRIPTION
Fixes #2182.

Also changed docs, as `system.get_clipboard` can return `nil`.