### PR TITLE
Fix python colon in strings

### DIFF
--- a/data/plugins/language_python.lua
+++ b/data/plugins/language_python.lua
@@ -162,7 +162,6 @@ syntax.add {
     { pattern = { "{",  "}"  },                                                syntax = not_python_type },
 
     { pattern = ":%s*()#.*",                   type = { "operator", "comment" }                         },
-    { pattern = { ":%s*", "%f[^%[%]%w_]"},                                     syntax = python_type     },
 
   }, python_patterns),
 


### PR DESCRIPTION
The original Python syntax relied on block-header rules that terminated at the first colon, which broke highlighting when colons appeared inside strings.
After removing those patterns, a top-level type-annotation rule incorrectly treated block colons as type contexts, breaking keyword/function highlighting.
I removed these, and everything works as expected, except type hints which are treated as normal text. But this is the case even with the original plugin (line 41 in the photo), which only treated them correctly when inside blocks (line 43).
Additionally, removing these lines fixes another problem: _print()_ and _returns_ were colored weirdly (either as functions or as variables with no reason (lines 56 & 58).

I attached a picture that shows the results:

- left side: Original plugin Lite-xl
- middle: VsCode
- right side: Plugin with those patterns removed Lite-xl

<img width="1245" height="883" alt="comparison" src="https://github.com/user-attachments/assets/26888bd1-c226-4b07-a3d4-c85be758b0cb" />

Thanks for looking over this!

Fixes #2190
