### PR TITLE
Fix Error in Process Read

### DIFF
--- a/src/api/process.c
+++ b/src/api/process.c
@@ -636,6 +636,7 @@ static int g_read(lua_State* L, int stream, lua_Integer read_size) {
 
       if (length == 0) {
         is_eof = true;
+        poll_process(self, WAIT_NONE);
         break;
       } else if (length < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
         length = 0;


### PR DESCRIPTION
It makes sense to return null from read when `g_read` is called and eof is reached. Thanks for to @lalelalela_90748 on discord for submitting this patch.

I added in `poll_process` in order to ensure the process is flagged as terminated if it is indeed exited.