### PR TITLE
Fix delete & rename commands for treeview

### DIFF
--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -613,7 +613,7 @@ end
 
 command.add(function()
   local item = treeitem()
-  return not is_project_folder(item), item
+  return item and not is_project_folder(item) and core.active_view == view, item
 end, {
   ["treeview:delete"] = function(item)
     local filename = item.abs_filename


### PR DESCRIPTION
Fixes the issue present in continuous build & locally (at least on Linux, but probably everywhere).

Pressing delete in text editor area triggered `delete` in tree view. User was prompted to confirm file deletion (issue: https://github.com/lite-xl/lite-xl/issues/2210)

After the fix, it behaves as expected - deletes the character.

<img width="905" height="754" alt="image" src="https://github.com/user-attachments/assets/c63c9267-336e-4026-852c-e1705c6544f9" />

<img width="1130" height="416" alt="image" src="https://github.com/user-attachments/assets/9ae92772-5294-49ac-bb2e-2f4cd6f0d4e8" />


