### PR TITLE
fix(renderer): remove custom freetype subpixel filter weights and enable ClearType-style subpixel rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build*/
 lhelper/
 submodules/
 subprojects/*/
+!subprojects/packagefiles/
 /appimage*
 .vscode
 .cache
@@ -10,6 +11,7 @@ subprojects/*/
 .lite-debug.log
 .run*
 *.diff
+!subprojects/packagefiles/**/*.diff
 *.exe
 *.tar.gz
 *.zip

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -168,11 +168,10 @@ static int font_set_render_options(RenFont* font) {
   if (font->antialiasing == FONT_ANTIALIASING_NONE)
     return FT_RENDER_MODE_MONO;
   if (font->antialiasing == FONT_ANTIALIASING_SUBPIXEL) {
-    unsigned char weights[] = { 0x10, 0x40, 0x70, 0x40, 0x10 } ;
     switch (font->hinting) {
       case FONT_HINTING_NONE: FT_Library_SetLcdFilter(library, FT_LCD_FILTER_NONE); break;
       case FONT_HINTING_SLIGHT:
-      case FONT_HINTING_FULL: FT_Library_SetLcdFilterWeights(library, weights); break;
+      case FONT_HINTING_FULL: FT_Library_SetLcdFilter(library, FT_LCD_FILTER_DEFAULT); break;
     }
     return FT_RENDER_MODE_LCD;
   } else {

--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -1,11 +1,10 @@
 [wrap-file]
-directory = freetype-2.14.1
-source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.14.1.tar.xz
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/freetype2_2.14.1-1/freetype-2.14.1.tar.xz
-source_filename = freetype-2.14.1.tar.xz
-source_hash = 32427e8c471ac095853212a37aef816c60b42052d4d9e48230bab3bdf2936ccc
-wrapdb_version = 2.14.1-1
+directory = freetype-2.14.2
+source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.14.2.tar.xz
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/freetype2_2.14.2-1/get_source/freetype-2.14.2.tar.xz
+source_filename = freetype-2.14.2.tar.xz
+source_hash = 4b62dcab4c920a1a860369933221814362e699e26f55792516d671e6ff55b5e1
+wrapdb_version = 2.14.2-1
 
 [provide]
-freetype2 = freetype_dep
-freetype = freetype_dep
+dependency_names = freetype2

--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -5,6 +5,7 @@ source_fallback_url = https://wrapdb.mesonbuild.com/v2/freetype2_2.14.2-1/get_so
 source_filename = freetype-2.14.2.tar.xz
 source_hash = 4b62dcab4c920a1a860369933221814362e699e26f55792516d671e6ff55b5e1
 wrapdb_version = 2.14.2-1
+diff_files = freetype2/enable_subpixel_rendering.diff
 
 [provide]
 dependency_names = freetype2

--- a/subprojects/packagefiles/freetype2/enable_subpixel_rendering.diff
+++ b/subprojects/packagefiles/freetype2/enable_subpixel_rendering.diff
@@ -1,0 +1,13 @@
+diff --git a/include/freetype/config/ftoption.h b/include/freetype/config/ftoption.h
+index fadfb9187..6a1f8125d 100644
+--- a/include/freetype/config/ftoption.h
++++ b/include/freetype/config/ftoption.h
+@@ -123,7 +123,7 @@ FT_BEGIN_HEADER
+    * When this macro is not defined, FreeType offers alternative LCD
+    * rendering technology that produces excellent output.
+    */
+-/* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */
++#define FT_CONFIG_OPTION_SUBPIXEL_RENDERING
+ 
+ 
+   /**************************************************************************


### PR DESCRIPTION
This:
1. fixes #2209,
2. updates to the latest freetype meson wrap,
3. enables ClearType-style subpixel rendering.

Should we set `FT_LCD_FILTER_LIGHT` when using `FONT_HINTING_SLIGHT`?