### PR TITLE
Make STDIN pipe synchronous on Windows

### DIFF
--- a/src/api/process.c
+++ b/src/api/process.c
@@ -452,14 +452,14 @@ static int process_start(lua_State* L) {
           if (new_fds[i] == i) {
             char pipeNameBuffer[MAX_PATH];
             sprintf(pipeNameBuffer, "\\\\.\\Pipe\\RemoteExeAnon.%08lx.%08lx", GetCurrentProcessId(), InterlockedIncrement(&PipeSerialNumber));
-            self->child_pipes[i][0] = CreateNamedPipeA(pipeNameBuffer, PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
+            self->child_pipes[i][0] = CreateNamedPipeA(pipeNameBuffer, PIPE_ACCESS_INBOUND | (i == STDIN_FD ? 0 : FILE_FLAG_OVERLAPPED),
               PIPE_TYPE_BYTE | PIPE_WAIT, 1, READ_BUF_SIZE, READ_BUF_SIZE, 0, NULL);
             if (self->child_pipes[i][0] == INVALID_HANDLE_VALUE) {
               push_error(L, "cannot create pipe", GetLastError());
               retval = -1;
               goto cleanup;
             }
-            self->child_pipes[i][1] = CreateFileA(pipeNameBuffer, GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+            self->child_pipes[i][1] = CreateFileA(pipeNameBuffer, GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | (i == STDIN_FD ? FILE_FLAG_OVERLAPPED : 0), NULL);
             if (self->child_pipes[i][1] == INVALID_HANDLE_VALUE) {
               // prevent CloseHandle from messing up error codes
               DWORD err = GetLastError();


### PR DESCRIPTION
This fixes an issues with applications that expect default STDIO
semantics of STDIO being sync by default.

The pipe orientation is the other way around for STDOUT and STDERR
so those are already sync for the subprocess and async for the editor.

I would prefer a solution that streamlines the orientations of all pipes so that this would not be needed during pipe creation however there is lots of code that explicitly deals with this that I do not want to touch.

Also backported to the last release on: [PR/2.1.x-sync-stdio](https://github.com/Jan200101/lite-xl/tree/PR/2.1.x-sync-stdio)